### PR TITLE
v1.3: CompoundSprite, ActiveLayer

### DIFF
--- a/app/lib/zif/actions/action.rb
+++ b/app/lib/zif/actions/action.rb
@@ -99,7 +99,8 @@ module Zif
       end
 
       perform_callback if @callback && complete?
-      return @dirty
+
+      @dirty
     end
 
     def progress

--- a/app/lib/zif/actions/sequence.rb
+++ b/app/lib/zif/actions/sequence.rb
@@ -28,10 +28,12 @@ module Zif
 
     def perform_tick
       # puts "Sequence#perform_tick"
-      cur_action.perform_tick
+      @dirty = cur_action.perform_tick
 
       next_action if cur_action.complete?
       perform_callback if complete? && @callback
+
+      @dirty
     end
 
     def cur_action

--- a/app/lib/zif/game.rb
+++ b/app/lib/zif/game.rb
@@ -59,6 +59,7 @@ module Zif
       @services.register(:sprite_registry, Zif::SpriteRegistry.new)
       @services.register(:input_service, Zif::InputService.new)
       @scene_registry = {}
+      @pause_actions = false
     end
 
     def register_scene(scene_name, scene)

--- a/app/lib/zif/labels/label.rb
+++ b/app/lib/zif/labels/label.rb
@@ -1,7 +1,13 @@
 module Zif
   # A basic label which is aware of it's size and can be truncated
   class Label
+    include Zif::Actionable
+
+    attr_accessor :x, :y, :r, :g, :b, :a
     attr_accessor :text, :max_width, :min_width, :min_height, :size, :align
+
+    alias alignment_enum align
+    alias size_enum size
 
     FONT = 'font.tff'.freeze
     ELLIPSIS = '…'.freeze

--- a/app/lib/zif/layered_tile_map/active_layer.rb
+++ b/app/lib/zif/layered_tile_map/active_layer.rb
@@ -1,0 +1,49 @@
+module Zif
+  # Designed to be used with Zif::LayeredTileMap.
+  # This layer is based on CompoundSprite and therefore all of the component sprites must be rendered every tick.
+  # Use this for layers with a small sprite count.
+  # The other layer classes are built on RenderTarget and therefore incur a little performance hit every time they are
+  # redrawn, but balance that by being able to cheaply display those sprites once rendered.
+  class ActiveLayer < CompoundSprite
+    include Layerable
+
+    def initialize(map, name, z=0)
+      super(name)
+      @map           = map
+      @layer_name    = name
+      @z             = z
+      @should_render = true # This does not control anything in this context since we are always rendering.
+      reinitialize_sprites
+
+      @x = 0
+      @y = 0
+      @w = @map.max_width
+      @h = @map.max_height
+      @source_x = 0
+      @source_y = 0
+      @source_w = @w
+      @source_h = @h
+    end
+
+    def containing_sprite
+      self
+    end
+
+    def source_sprites
+      @sprites
+    end
+
+    def source_sprites=(new_sprites)
+      @sprites = new_sprites
+    end
+
+    def reinitialize_sprites
+      @sprites = []
+    end
+
+    # No-op
+    def rerender
+      true
+    end
+  end
+end

--- a/app/lib/zif/layered_tile_map/layerable.rb
+++ b/app/lib/zif/layered_tile_map/layerable.rb
@@ -1,0 +1,66 @@
+module Zif
+  # Functionality shared between SimpleLayer & ActiveLayer
+  module Layerable
+    attr_accessor :map, :layer_name, :z, :should_render
+
+    def add_positioned_sprite(sprite)
+      source_sprites << position_sprite(sprite, logical_x, logical_y)
+    end
+
+    def position_sprite(sprite, logical_x, logical_y)
+      # Skip Sprite#assign, this is perf critical
+      sprite.x         = logical_x * @map.tile_width
+      sprite.y         = logical_y * @map.tile_height
+      sprite.logical_x = logical_x
+      sprite.logical_y = logical_y
+      sprite
+    end
+
+    # This only removes it from the data layer, you'll need to redraw to remove it visually
+    def remove_sprite(tile)
+      source_sprites.delete(tile)
+    end
+
+    def target_layer_name
+      "#{@map.target_name}_#{@layer_name}"
+    end
+
+    # This is not very performant with lots of sprites!  Consider using TiledLayer instead.
+    def visible_sprites(rect=containing_sprite.source_rect)
+      source_sprites.select do |sprite|
+        sprite.intersect_rect? rect
+      end
+    end
+
+    # Returns an array of colliding sprites, and non-colliding sprites that were within the visible area
+    def collisions(rect)
+      remain = visible_sprites(rect).to_a
+      coll   = remain.select { |item| item.intersect_rect? rect }
+      [coll, coll - remain]
+    end
+
+    def clicked?(point, kind=:up)
+      relative_point = Zif.add_positions(
+        Zif.position_math(
+          :mult,
+          point,
+          Zif.position_math(
+            :fdiv,
+            containing_sprite.source_wh,
+            containing_sprite.wh
+          )
+        ),
+        containing_sprite.source_xy
+      )
+      visible_sprites(
+        relative_point + [1, 1]
+      ).reverse_each.find do |sprite|
+        sprite.respond_to?(:clicked?) && sprite.clicked?(relative_point, kind)
+      end
+    end
+
+    def exclude_from_serialize
+      %w[source_sprites sprites primitives]
+    end
+  end
+end

--- a/app/lib/zif/layered_tile_map/layered_tile_map.rb
+++ b/app/lib/zif/layered_tile_map/layered_tile_map.rb
@@ -48,6 +48,12 @@ module Zif
       @tracer_service_name = :tracer
     end
 
+    def new_active_layer(name)
+      @layers[name] = Zif::ActiveLayer.new(self, name, @z)
+      @z += 1
+      return @layers[name]
+    end
+
     def new_simple_layer(name, render_only_visible=false, clear_sprites_after_draw=false)
       @layers[name] = Zif::SimpleLayer.new(self, name, @z, render_only_visible, clear_sprites_after_draw)
       @z += 1

--- a/app/lib/zif/layered_tile_map/simple_layer.rb
+++ b/app/lib/zif/layered_tile_map/simple_layer.rb
@@ -2,8 +2,8 @@ module Zif
   # Designed to be used with Zif::LayeredTileMap.
   # A simple layer consisting of an initially empty array of sprites.
   class SimpleLayer < RenderTarget
-    attr_accessor :map, :layer_name, :z, :source_sprites
-    attr_accessor :should_render, :render_only_visible, :clear_sprites_after_draw, :rerender_rect
+    include Layerable
+    attr_accessor :source_sprites, :render_only_visible, :clear_sprites_after_draw, :rerender_rect
 
     def initialize(map, name, z=0, render_only_visible=false, clear_sprites_after_draw=false)
       @map                      = map
@@ -20,42 +20,6 @@ module Zif
 
     def reinitialize_sprites
       @source_sprites = []
-    end
-
-    def target_layer_name
-      "#{@map.target_name}_#{@layer_name}"
-    end
-
-    # Returns an array of colliding sprites, and non-colliding sprites that were within the visible area
-    def collisions(rect)
-      remain = visible_sprites(rect).to_a
-      coll   = remain.select { |item| item.intersect_rect? rect }
-      [coll, coll - remain]
-    end
-
-    # This is not very performant with lots of sprites!  Consider using TiledLayer instead.
-    def visible_sprites(rect=containing_sprite.source_rect)
-      @source_sprites.select do |sprite|
-        sprite.intersect_rect? rect
-      end
-    end
-
-    def position_sprite(sprite, logical_x, logical_y)
-      # Skip Sprite#assign, this is perf critical
-      sprite.x         = logical_x * @map.tile_width
-      sprite.y         = logical_y * @map.tile_height
-      sprite.logical_x = logical_x
-      sprite.logical_y = logical_y
-      sprite
-    end
-
-    def add_positioned_sprite(sprite)
-      @source_sprites << position_sprite(sprite, logical_x, logical_y)
-    end
-
-    # This only removes it from the data layer, you'll need to redraw to remove it visually
-    def remove_sprite(tile)
-      @source_sprites.delete(tile)
     end
 
     def rerender
@@ -76,30 +40,6 @@ module Zif
       reinitialize_sprites if @clear_sprites_after_draw
 
       true
-    end
-
-    def clicked?(point, kind=:up)
-      relative_point = Zif.add_positions(
-        Zif.position_math(
-          :mult,
-          point,
-          Zif.position_math(
-            :fdiv,
-            containing_sprite.source_wh,
-            containing_sprite.wh
-          )
-        ),
-        containing_sprite.source_xy
-      )
-      visible_sprites(
-        relative_point + [1, 1]
-      ).reverse_each.find do |sprite|
-        sprite.respond_to?(:clicked?) && sprite.clicked?(relative_point, kind)
-      end
-    end
-
-    def exclude_from_serialize
-      %w[source_sprites sprites primitives]
     end
   end
 end

--- a/app/lib/zif/sprites/compound_sprite.rb
+++ b/app/lib/zif/sprites/compound_sprite.rb
@@ -1,0 +1,71 @@
+module Zif
+  # A CompoundSprite is a collection of sprites which can be positioned as a group.
+  class CompoundSprite < Sprite
+    attr_accessor :sprites, :labels
+
+    def initialize(name=:unknown)
+      super(name)
+      @sprites     = []
+      @labels      = []
+    end
+
+    def draw_override(ffi_draw)
+      x_zoom, y_zoom = zoom_factor
+      cur_source_rect = source_rect
+
+      # Since this "sprite" itself won't actually be drawn, we can use the positioning attributes to control the
+      # contained sprites.
+      # x/y: linear offset
+      # w/h: used for #zoom_factor, derived with comparison to source_w/h (Sprite method)
+      # source_x/y: position of visible window
+      # source_w/h: extent of visible window.  Unfortunately we can't clip sprites in half using this method.
+      #             Therefore, anything even *partially* visible will be *fully* drawn.
+
+      @sprites.each do |sprite|
+        cur_rect = sprite.rect
+
+        next unless cur_rect.intersect_rect? cur_source_rect
+
+        x, y, w, h = cur_rect
+
+        ffi_draw.draw_sprite_3(
+          ((x - @source_x) * x_zoom) + @x,
+          ((y - @source_y) * y_zoom) + @y,
+          w * x_zoom,
+          h * y_zoom,
+          sprite.path.s_or_default,
+          sprite.angle,
+          sprite.a,
+          sprite.r,
+          sprite.g,
+          sprite.b,
+          nil, nil, nil, nil, # Don't use tile_*
+          sprite.flip_horizontally,
+          sprite.flip_vertically,
+          sprite.angle_anchor_x,
+          sprite.angle_anchor_y,
+          sprite.source_x,
+          sprite.source_y,
+          sprite.source_w,
+          sprite.source_h
+        )
+      end
+
+      @labels.each do |label|
+        # TODO: Skip if not in visible window
+        ffi_draw.draw_label(
+          ((label.x - @source_x) * x_zoom) + @x,
+          ((label.y - @source_y) * y_zoom) + @y,
+          label.text.s_or_default,
+          label.size_enum,
+          label.alignment_enum,
+          label.r,
+          label.g,
+          label.b,
+          label.a,
+          label.font.s_or_default(nil)
+        )
+      end
+    end
+  end
+end

--- a/app/lib/zif/sprites/sprite.rb
+++ b/app/lib/zif/sprites/sprite.rb
@@ -72,27 +72,6 @@ module Zif
       @render_target.clicked?(point, kind)
     end
 
-    # Experimenting with draw_override, please ignore
-    #
-    # def primitive_marker
-    #   :sprite
-    # end
-    #
-    # def sprite
-    #   self
-    # end
-    #
-    # def draw_override(ffi_draw)
-    #   ffi_draw.draw_sprite_3 @x, @y, @w, @h,
-    #                               @path.s_or_default,
-    #                               @angle,
-    #                               @a, @r, @g, @b,
-    #                               nil, nil, nil, nil,
-    #                               !!@flip_horizontally, !!@flip_vertically,
-    #                               0.5, 0.5,
-    #                               @source_x, @source_y, @source_w, @source_h
-    # end
-
     # ------------------------
     # Some convenience methods
 
@@ -153,6 +132,10 @@ module Zif
 
     def source_center
       [(@source_x + @source_w.idiv(2)).to_i, (@source_y + @source_h.idiv(2)).to_i]
+    end
+
+    def zoom_factor
+      [@w.fdiv(@source_w), @h.fdiv(@source_h)]
     end
 
     def source_rect_hash

--- a/app/main.rb
+++ b/app/main.rb
@@ -4,7 +4,6 @@ require 'app/lib/zif/sprites/serializable.rb'
 require 'app/lib/zif/services/services.rb'
 require 'app/lib/zif/services/input_service.rb'
 require 'app/lib/zif/services/tick_trace_service.rb'
-require 'app/lib/zif/labels/label.rb'
 
 # Expects $services to be services.rb, works with tick_trace_service.rb
 require 'app/lib/zif/trace/traceable.rb'
@@ -22,6 +21,9 @@ require 'app/lib/zif/actions/sequence.rb'
 # Depends on action.rb, sequence.rb
 require 'app/lib/zif/actions/actionable.rb'
 
+# Depends on actionable.rb
+require 'app/lib/zif/labels/label.rb'
+
 # Depends on sequence.rb - expects an Actionable class
 require 'app/lib/zif/actions/animatable.rb'
 require 'app/lib/zif/services/action_service.rb'
@@ -31,6 +33,7 @@ require 'app/lib/zif/sprites/sprite.rb'
 
 # Depends on sprite.rb, zif.rb
 require 'app/lib/zif/sprites/render_target.rb'
+require 'app/lib/zif/sprites/compound_sprite.rb'
 
 # Depends on render_target.rb
 require 'app/lib/zif/sprites/complex_sprite.rb'
@@ -48,6 +51,10 @@ require 'app/lib/zif/scenes/hud.rb'
 
 # Depends on actionable.rb, zif.rb, - expects $game to be a game.rb
 require 'app/lib/zif/camera.rb'
+
+# Depends on compound_sprite.rb, expects to be initialized with a LayeredTileMap-like @map
+require 'app/lib/zif/layered_tile_map/layerable.rb'
+require 'app/lib/zif/layered_tile_map/active_layer.rb'
 
 # Depends on render_target.rb, expects to be initialized with a LayeredTileMap-like @map
 require 'app/lib/zif/layered_tile_map/simple_layer.rb'
@@ -68,10 +75,12 @@ require 'app/ui/panels/metal_cutout.rb'
 require 'app/ui/components/progress_bar.rb'
 require 'app/ui/components/tall_button.rb'
 
+require 'app/scenes/zif_example_scene.rb'
 require 'app/scenes/world.rb'
 require 'app/scenes/world_loader.rb'
 require 'app/scenes/ui_sample.rb'
 require 'app/scenes/double_buffer_render_test.rb'
+require 'app/scenes/compound_sprite_test.rb'
 
 require 'app/avatar.rb'
 
@@ -88,6 +97,7 @@ class ZifExample < Zif::Game
     register_scene(:ui_sample, UISample)
     register_scene(:load_world, WorldLoader)
     register_scene(:load_double_buffer_render_test, DoubleBufferRenderTest)
+    register_scene(:load_compound_sprite_test, CompoundSpriteTest)
     @scene = UISample.new
   end
 end

--- a/app/scenes/compound_sprite_test.rb
+++ b/app/scenes/compound_sprite_test.rb
@@ -1,0 +1,156 @@
+# Demonstrating usage of a CompoundSprite with actions
+class CompoundSpriteTest < ZifExampleScene
+  include Zif::Traceable
+
+  attr_accessor :compound_sprite
+
+  def initialize
+    super
+    @tracer_service_name = :tracer
+    @next_scene = :ui_sample
+
+    @compound_sprite = Zif::CompoundSprite.new.tap do |s|
+      s.x = 100
+      s.y = 100
+      s.w = 800
+      s.h = 400
+      s.source_x = 0
+      s.source_y = 0
+      s.source_w = 800
+      s.source_h = 400
+    end
+
+    @outline = $game.services[:sprite_registry].construct(:white_1).tap do |s|
+      s.x = 100
+      s.y = 100
+      s.w = 800
+      s.h = 400
+      s.source_x = 0
+      s.source_y = 0
+      s.source_w = 800
+      s.source_h = 400
+      s.a = 30
+    end
+
+    [[0, 50], [100, 150], [0, 250]].each do |pos|
+      dragon = $game.services[:sprite_registry].construct('dragon_1').tap do |s|
+        s.name = "dragon_#{pos.inspect}"
+        s.x = pos[0]
+        s.y = pos[1]
+      end
+
+      finish_pos = 1000 - pos[0]
+
+      dragon.run(
+        Zif::Sequence.new(
+          [
+            dragon.new_action(
+              {x: finish_pos}, 10.seconds, :smooth_start
+            ) { dragon.flip_horizontally = true },
+            dragon.new_action(
+              {x: pos[0]}, 10.seconds, :smooth_stop
+            ) { dragon.flip_horizontally = false }
+          ],
+          :forever
+        )
+      )
+
+      dragon.run(
+        Zif::Sequence.new(
+          [
+            dragon.new_action({y: pos[1] + 300}, 5.seconds, :smooth_start),
+            dragon.new_action({y: pos[1] - 300}, 5.seconds, :smooth_stop)
+          ],
+          :forever
+        )
+      )
+
+      dragon.new_basic_animation(
+        :fly,
+        1.upto(4).map { |i| ["dragon_#{i}", 4] } + 3.downto(2).map { |i| ["dragon_#{i}", 4] }
+      )
+
+      dragon.run_animation_sequence(:fly)
+
+      @compound_sprite.sprites << dragon
+    end
+
+    dragon_label = Zif::Label.new('A Thunder of Dragons', 0, 1).tap do |label|
+      label.x = 50
+      label.y = 0
+      label.r = 255
+      label.g = 255
+      label.b = 255
+      label.a = 255
+    end
+
+    dragon_label.run(
+      Zif::Sequence.new(
+        [
+          dragon_label.new_action({x: 1000}, 10.seconds, :smooth_start),
+          dragon_label.new_action({x: 0   }, 10.seconds, :smooth_stop)
+        ],
+        :forever
+      )
+    )
+
+    @compound_sprite.labels << dragon_label
+
+    [@outline, @compound_sprite].each do |sprite|
+      sprite.run(
+        Zif::Sequence.new(
+          [
+            sprite.new_action({x: 300}, 6.seconds, :linear),
+            sprite.new_action({x: 100}, 6.seconds, :linear)
+          ],
+          :forever
+        )
+      )
+
+      sprite.run(
+        Zif::Sequence.new(
+          [
+            sprite.new_action({y: 300}, 3.seconds, :linear),
+            sprite.new_action({y: 100}, 3.seconds, :linear)
+          ],
+          :forever
+        )
+      )
+    end
+  end
+
+  def prepare_scene
+    super
+
+    @compound_sprite.sprites.each do |dragon|
+      $game.services[:action_service].register_actionable(dragon)
+    end
+    @compound_sprite.labels.each do |dragon_label|
+      $game.services[:action_service].register_actionable(dragon_label)
+    end
+
+    $game.services[:action_service].register_actionable(@compound_sprite)
+    $game.services[:action_service].register_actionable(@outline)
+
+    $gtk.args.outputs.static_sprites << @outline
+    $gtk.args.outputs.static_sprites << @compound_sprite
+  end
+
+  def perform_tick
+    mark('#perform_tick: Start')
+    $gtk.args.outputs.background_color = [0, 0, 0, 0]
+
+    @compound_sprite.source_h += 100 if $gtk.args.inputs.keyboard.key_up.up
+    @compound_sprite.source_h -= 100 if $gtk.args.inputs.keyboard.key_up.down
+    @compound_sprite.source_w += 100 if $gtk.args.inputs.keyboard.key_up.right
+    @compound_sprite.source_w -= 100 if $gtk.args.inputs.keyboard.key_up.left
+
+    # rubocop:disable Layout/LineLength
+    $gtk.args.outputs.labels << { x: 8, y: 100, text: 'Up/Down: Modify source_h.  Right/Left: Modify source_w.', r: 255, g: 255, b: 255, a: 255}
+    $gtk.args.outputs.labels << { x: 8, y: 80, text: "Compund Sprite: #{@compound_sprite.rect} -> #{@compound_sprite.source_rect}.  Zoom #{@compound_sprite.zoom_factor}", r: 255, g: 255, b: 255, a: 255}
+    # rubocop:enable Layout/LineLength
+
+    mark('#perform_tick: Finished')
+    super
+  end
+end

--- a/app/scenes/world_loader.rb
+++ b/app/scenes/world_loader.rb
@@ -2,9 +2,12 @@
 # It's required because the World will take a little while to generate all of the floor sprites
 # It's also a demonstration of automatic scene switching
 class WorldLoader < Zif::Scene
+  include Zif::Traceable
+
   attr_accessor :world, :ready
 
   def initialize
+    @tracer_service_name = :tracer
     @world = World.new
     @ready = false
     @floor_progress = ProgressBar.new(:world_loader_progress, 640, @world.initialization_percent(:tiles), :green)
@@ -57,6 +60,13 @@ class WorldLoader < Zif::Scene
     end
     $gtk.args.outputs.sprites << sprites
     $gtk.args.outputs.labels << labels
+
+    # rubocop:disable Layout/LineLength
+    color = {r: 255, g: 255, b: 255, a: 255}
+    $gtk.args.outputs.labels << { x: 8, y: 720 - 8, text: "#{self.class.name}." }.merge(color)
+    $gtk.args.outputs.labels << { x: 8, y: 720 - 28, text: "#{tracer&.last_tick_ms} #{$gtk.args.gtk.current_framerate}fps" }.merge(color)
+    $gtk.args.outputs.labels << { x: 8, y: 60, text: "Last slowest mark: #{tracer&.slowest_mark}" }.merge(color)
+    # rubocop:enable Layout/LineLength
 
     # Returning the other Scene instance so the Game knows to switch scenes.  Demonstrating an automatic scene switch
     return @world if @ready

--- a/app/scenes/zif_example_scene.rb
+++ b/app/scenes/zif_example_scene.rb
@@ -1,0 +1,46 @@
+# Just some shared functionality across all Zif example app scenes.
+class ZifExampleScene < Zif::Scene
+  include Zif::Traceable
+
+  attr_accessor :tracer_service_name, :scene_timer, :next_scene
+
+  def initialize
+    @tracer_service_name = :tracer
+    @scene_timer = 60 * 60
+    @pause_timer = false
+  end
+
+  def prepare_scene
+    # You probably want to remove the things registered with the services when scenes change
+    # You can remove items explicitly using #remove_.., but #reset_.. will clear everything
+    # You can also do this when a scene is being changed away from, using the #unload_scene method.
+    $game.services[:action_service].reset_actionables
+    $game.services[:input_service].reset
+    $gtk.args.outputs.static_sprites.clear
+    $gtk.args.outputs.static_labels.clear
+  end
+
+  def perform_tick
+    display_context_labels
+
+    if $gtk.args.inputs.keyboard.key_up.pageup
+      @pause_timer = !@pause_timer
+      @scene_timer += 100 if @pause_timer
+    end
+
+    @scene_timer -= 1 unless @pause_timer
+
+    return unless @next_scene
+
+    return @next_scene if @force_next_scene || $gtk.args.inputs.keyboard.key_up.space || !@scene_timer.positive?
+  end
+
+  # rubocop:disable Layout/LineLength
+  def display_context_labels
+    color = {r: 255, g: 255, b: 255, a: 255}
+    $gtk.args.outputs.labels << { x: 8, y: 720 - 8, text: "#{self.class.name}.  Press spacebar to transition to #{@next_scene}, or wait #{@scene_timer} ticks." }.merge(color)
+    $gtk.args.outputs.labels << { x: 8, y: 720 - 28, text: "#{tracer&.last_tick_ms} #{$gtk.args.gtk.current_framerate}fps" }.merge(color)
+    $gtk.args.outputs.labels << { x: 8, y: 60, text: "Last slowest mark: #{tracer&.slowest_mark}" }.merge(color)
+  end
+  # rubocop:enable Layout/LineLength
+end


### PR DESCRIPTION
- `Zif::CompoundSprite`: a collection of sprites which are positioned as a group, implemented with `#draw_override`
- `Zif::ActiveLayer`: Like `SimpleLayer` but implemented with a `CompoundSprite` instead of `RenderTarget`
- Moved shared code between `SimpleLayer` and `ActiveLayer` to `Layerable`
- `LayeredTileMap#new_active_layer`
- `CompoundSprite` support: Some fixes for `Label`
- Changes to require order.
- Fixed `@dirty` not being returned from `Sequence#perform_tick`
- Example App:
  - `CompoundSpriteTest` scene demonstrating usage of `CompoundSprite`
  - `ZifExampleScene` for shared example scene code (debug printing, etc)
  - Scenes now auto-advance after some time. Pressing `Page Up` pauses/unpauses the timer.  Pressing `Space` advances.