### PR TITLE
Zif v1.5: Active Tiled Layers

### DIFF
--- a/app/lib/zif/actions/actionable.rb
+++ b/app/lib/zif/actions/actionable.rb
@@ -37,6 +37,11 @@ module Zif
       Action.new(self, *args, &block)
     end
 
+    # Empty action - just a wait and a callback
+    def delayed_action(wait, repeat=1, &block)
+      new_action({}, wait, :linear, :round, repeat, &block)
+    end
+
     # -----------------------
     # Some example factories:
     def bounce_forever_around(y=110, distance=15, duration=5.seconds)

--- a/app/lib/zif/camera.rb
+++ b/app/lib/zif/camera.rb
@@ -10,7 +10,7 @@ module Zif
     attr_accessor :layers, :layer_index
 
     attr_accessor :max_x, :max_y, :min_x, :min_y, :target_x, :target_y, :max_w, :max_h,
-                  :max_zoom_in, :max_zoom_out, :zoom_step, :native_screen_width, :native_screen_height
+                  :max_zoom_in, :max_zoom_out, :zoom_step, :zoom_steps, :native_screen_width, :native_screen_height
 
     attr_reader :pos_x, :pos_y, :cur_w, :cur_h
 
@@ -55,7 +55,9 @@ module Zif
       @max_zoom_out = 2.0
 
       # Each scroll action will increase or decrease zoom factor by this amount:
-      @zoom_step = 0.1
+      @zoom_steps = [0.5, 0.8, 1.0, 1.28, 1.6, 2.0]
+      # Index of above
+      @zoom_step = 2
 
       self.cur_w = starting_width
       self.cur_h = starting_height
@@ -258,17 +260,19 @@ module Zif
     end
 
     def zoom_out(point=(@last_follow || center))
-      zoom_to([zoom_factor.first + @zoom_step, @max_zoom_out].min, point)
+      @zoom_step = [@zoom_step+1, @zoom_steps.length - 1].min
+      zoom_to(@zoom_steps[@zoom_step], point)
     end
 
     def zoom_in(point=(@last_follow || center))
-      zoom_to([zoom_factor.first - @zoom_step, @max_zoom_in].max, point)
+      @zoom_step = [@zoom_step-1, 0].max
+      zoom_to(@zoom_steps[@zoom_step], point)
     end
 
     def zoom_to(factor=1.0, point=(@last_follow || center))
-      base_mult = (factor.round(1) * 80).floor
-      self.cur_w = base_mult * 16
-      self.cur_h = base_mult * 9
+      base_mult = (factor.round(2) * 80)
+      self.cur_w = (base_mult * 16)
+      self.cur_h = (base_mult * 9)
 
       # puts "#zoom_to: Zoomed to #{zoom_factor}"
 

--- a/app/lib/zif/components/two_stage_button.rb
+++ b/app/lib/zif/components/two_stage_button.rb
@@ -23,7 +23,7 @@ module Zif
     end
 
     def toggle_on_change(point)
-      toggle_pressed if point.inside_rect?(rect) != @is_pressed
+      toggle_pressed if point.inside_rect?(self) != @is_pressed
     end
 
     def press

--- a/app/lib/zif/game.rb
+++ b/app/lib/zif/game.rb
@@ -36,7 +36,7 @@
 #        water_level = WaterLevelScene.new
 #        water_level.do_special_stuff # like something you can't do in #prepare_scene for whatever reason
 #        @scene = water_level
-#      else # an unhan
+#      else # an unhandled return
 #        @scene = OpeningScene.new
 #      end
 #    end
@@ -92,8 +92,8 @@ module Zif
 
       mark('#standard_tick: Scene switching handled')
 
-      @services[:action_service].run_all_actions
-      mark('#standard_tick: end')
+      mark('#standard_tick: Action service complete') if @services[:action_service].run_all_actions
+      mark('#standard_tick: Complete')
       @services[:tracer].finish
     rescue StandardError => e
       decorate_exception(e)

--- a/app/lib/zif/layered_tile_map/active_layer.rb
+++ b/app/lib/zif/layered_tile_map/active_layer.rb
@@ -38,6 +38,7 @@ module Zif
     end
 
     def reinitialize_sprites
+      # puts "#{@layer_name}: ActiveLayer reinitialize_sprites"
       @sprites = []
     end
 

--- a/app/lib/zif/layered_tile_map/active_layer.rb
+++ b/app/lib/zif/layered_tile_map/active_layer.rb
@@ -29,16 +29,20 @@ module Zif
       self
     end
 
+    def add_positioned_sprite(logical_x, logical_y, sprite)
+      # puts "ActiveLayer#add_positioned_sprite: #{logical_x} #{logical_y}"
+      @sprites << position_sprite(sprite, logical_x, logical_y)
+    end
+
+    def remove_sprite(sprite)
+      @sprites.delete(sprite)
+    end
+
     def source_sprites
       @sprites
     end
 
-    def source_sprites=(new_sprites)
-      @sprites = new_sprites
-    end
-
     def reinitialize_sprites
-      # puts "#{@layer_name}: ActiveLayer reinitialize_sprites"
       @sprites = []
     end
 

--- a/app/lib/zif/layered_tile_map/bitmasked_tiled_layer.rb
+++ b/app/lib/zif/layered_tile_map/bitmasked_tiled_layer.rb
@@ -28,11 +28,8 @@ module Zif
     end
 
     def remove_at(x, y)
-      # puts "#remove_at: #{x}, #{y}: was #{@source_sprites[y][x]}"
       @presence_data[y][x] = false
-      @source_sprites[y][x] = nil
-      sync_sprites_at(x, y)
-      # puts "#remove_at: #{x}, #{y}: now #{@source_sprites[y][x]}"
+      remove_tile(y, x)
       redraw_at(x, y)
     end
 
@@ -102,22 +99,20 @@ module Zif
 
       (from_y..to_y).each do |i|
         (from_x..to_x).each do |j|
-          @source_sprites[i][j] = nil
-          sync_sprites_at(j, i)
+          remove_tile(i, j)
           bitmask = @bitmask_data[i][j]
           next unless bitmask
 
           full_name = "#{@bitmasked_sprite_name_prefix}_#{bitmask}".to_sym
           sprite = $services[:sprite_registry].construct(full_name)
 
-          @source_sprites[i][j] = position_sprite(sprite, j, i)
-          sync_sprites_at(j, i)
+          add_positioned_sprite(j, i, sprite)
         end
       end
     end
 
     def exclude_from_serialize
-      %w[presence_data bitmask_data source_sprites sprites primitives]
+      %w[presence_data bitmask_data sprites primitives]
     end
   end
 

--- a/app/lib/zif/layered_tile_map/bitmasked_tiled_layer.rb
+++ b/app/lib/zif/layered_tile_map/bitmasked_tiled_layer.rb
@@ -18,7 +18,7 @@ module Zif
   #
   # Some background (note the author uses a different numbering scheme):
   # https://gamedevelopment.tutsplus.com/tutorials/how-to-use-tile-bitmasking-to-auto-tile-your-level-layouts--cms-25673
-  class BitmaskedTiledLayer < TiledLayer
+  module Bitmaskable
     attr_accessor :presence_data, :bitmask_data, :bitmasked_sprite_name_prefix
 
     def reinitialize_sprites
@@ -31,6 +31,7 @@ module Zif
       # puts "#remove_at: #{x}, #{y}: was #{@source_sprites[y][x]}"
       @presence_data[y][x] = false
       @source_sprites[y][x] = nil
+      sync_sprites_at(x, y)
       # puts "#remove_at: #{x}, #{y}: now #{@source_sprites[y][x]}"
       redraw_at(x, y)
     end
@@ -102,6 +103,7 @@ module Zif
       (from_y..to_y).each do |i|
         (from_x..to_x).each do |j|
           @source_sprites[i][j] = nil
+          sync_sprites_at(j, i)
           bitmask = @bitmask_data[i][j]
           next unless bitmask
 
@@ -109,6 +111,7 @@ module Zif
           sprite = $services[:sprite_registry].construct(full_name)
 
           @source_sprites[i][j] = position_sprite(sprite, j, i)
+          sync_sprites_at(j, i)
         end
       end
     end
@@ -116,5 +119,15 @@ module Zif
     def exclude_from_serialize
       %w[presence_data bitmask_data source_sprites sprites primitives]
     end
+  end
+
+  class BitmaskedTiledLayer < SimpleLayer
+    include Tileable
+    include Bitmaskable
+  end
+
+  class ActiveBitmaskedTiledLayer < ActiveLayer
+    include Tileable
+    include Bitmaskable
   end
 end

--- a/app/lib/zif/layered_tile_map/layerable.rb
+++ b/app/lib/zif/layered_tile_map/layerable.rb
@@ -3,8 +3,13 @@ module Zif
   module Layerable
     attr_accessor :map, :layer_name, :z, :should_render
 
-    def add_positioned_sprite(sprite)
+    def add_positioned_sprite(logical_x, logical_y, sprite)
+      puts "#{@layer_name}: Layerable#add_positioned_sprite"
       source_sprites << position_sprite(sprite, logical_x, logical_y)
+    end
+
+    def remove_positioned_sprite(sprite)
+      remove_sprite(sprite)
     end
 
     def position_sprite(sprite, logical_x, logical_y)

--- a/app/lib/zif/layered_tile_map/layerable.rb
+++ b/app/lib/zif/layered_tile_map/layerable.rb
@@ -3,11 +3,6 @@ module Zif
   module Layerable
     attr_accessor :map, :layer_name, :z, :should_render
 
-    def add_positioned_sprite(logical_x, logical_y, sprite)
-      puts "#{@layer_name}: Layerable#add_positioned_sprite"
-      source_sprites << position_sprite(sprite, logical_x, logical_y)
-    end
-
     def remove_positioned_sprite(sprite)
       remove_sprite(sprite)
     end
@@ -19,11 +14,6 @@ module Zif
       sprite.logical_x = logical_x
       sprite.logical_y = logical_y
       sprite
-    end
-
-    # This only removes it from the data layer, you'll need to redraw to remove it visually
-    def remove_sprite(tile)
-      source_sprites.delete(tile)
     end
 
     def target_layer_name
@@ -49,12 +39,13 @@ module Zif
     end
 
     def intersecting_sprites(compare_left, compare_bottom, compare_right, compare_top)
+      # puts "Layerable#intersecting_sprites: #{@layer_name} #{source_sprites.length}"
       source_sprites.select do |sprite|
         x = sprite.x
         y = sprite.y
         w = sprite.w
         h = sprite.h
-
+        # puts "Layerable#intersecting_sprites: #{x} #{y} #{w} #{h}"
         !(
           (x     > compare_right)  ||
           (y     > compare_top)    ||
@@ -77,13 +68,16 @@ module Zif
         ),
         containing_sprite.source_xy
       )
+
+      # puts "Layerable#clicked?(#{point}): #{@layer_name} #{x} #{y}"
       intersecting_sprites(x, y, x, y).reverse_each.find do |sprite|
+        # puts "  clicked? -> #{sprite}"
         sprite.respond_to?(:clicked?) && sprite.clicked?([x, y], kind)
       end
     end
 
     def exclude_from_serialize
-      %w[source_sprites sprites primitives]
+      %w[sprites primitives]
     end
   end
 end

--- a/app/lib/zif/layered_tile_map/layered_tile_map.rb
+++ b/app/lib/zif/layered_tile_map/layered_tile_map.rb
@@ -118,7 +118,7 @@ module Zif
 
     def refresh
       @layers.each do |layer_name, layer|
-        mark("#refresh: Rerendering #{layer_name} at #{layer.containing_sprite.source_rect}")
+        mark("#refresh: Rerendering #{layer_name}")
         layer.rerender
         mark("#refresh: Rerendered #{layer_name}")
       end

--- a/app/lib/zif/layered_tile_map/layered_tile_map.rb
+++ b/app/lib/zif/layered_tile_map/layered_tile_map.rb
@@ -10,11 +10,11 @@ module Zif
   #
   # As an example, you can have a "tiles" layer which gets redrawn only at the start of the game, an "interactive
   # objects" layer which gets redrawn whenever objects appear or disappear, and then an "avatar" layer which gets
-  # redrawn every time the avatar moves.  The advantage of using RenderTargets here is to keep the positioning
-  # consistent across all of the layers.  You can just pass all of the RT containing sprites to Camera and it will
-  # pan them all in unison.
+  # redrawn every time the avatar moves.  The advantage of using RenderTargets and CompoundSprites here is to keep the
+  # positioning consistent across all of the layers.  You can just pass all of the RT containing sprites to Camera and
+  # it will pan them all in unison.
   #
-  # You setup and configure these layers via #new_simple_layer and #new_tiled_layer.
+  # You setup and configure these layers via #new_simple_layer, #new_tiled_layer, etc.
   #
   # Performance notes:
   #  - Since the memory requirements here are based on the number of layers * area of each layer, consider other
@@ -25,9 +25,7 @@ module Zif
   #    hiccups if you do this often.  Try not to redraw RTs with lots of sprites while action is happening.
   class LayeredTileMap
     include Zif::Traceable
-    attr_accessor :target_name
-    attr_accessor :tile_width, :tile_height, :logical_width, :logical_height, :z
-    attr_accessor :layers
+    attr_accessor :target_name, :tile_width, :tile_height, :logical_width, :logical_height, :z, :layers
 
     # logical_ refers to integer multiples of tiles
     # Setup vars, setup render_targets
@@ -54,13 +52,13 @@ module Zif
       return @layers[name]
     end
 
+    # clear_sprites_after_draw kind of replicates the behavior of outputs.sprites vs outputs.static_sprites
     def new_simple_layer(name, render_only_visible=false, clear_sprites_after_draw=false)
       @layers[name] = Zif::SimpleLayer.new(self, name, @z, render_only_visible, clear_sprites_after_draw)
       @z += 1
       return @layers[name]
     end
 
-    # You really don't want clear_sprites_after_draw
     def new_tiled_layer(name, render_only_visible=false)
       @layers[name] = Zif::TiledLayer.new(self, name, @z, render_only_visible)
       @z += 1

--- a/app/lib/zif/layered_tile_map/layered_tile_map.rb
+++ b/app/lib/zif/layered_tile_map/layered_tile_map.rb
@@ -46,29 +46,35 @@ module Zif
       @tracer_service_name = :tracer
     end
 
-    def new_active_layer(name)
-      @layers[name] = Zif::ActiveLayer.new(self, name, @z)
+    def add_layer(name, layer)
+      @layers[name] = layer
       @z += 1
       return @layers[name]
+    end
+
+    def new_active_layer(name)
+      add_layer(name, Zif::ActiveLayer.new(self, name, @z))
     end
 
     # clear_sprites_after_draw kind of replicates the behavior of outputs.sprites vs outputs.static_sprites
     def new_simple_layer(name, render_only_visible=false, clear_sprites_after_draw=false)
-      @layers[name] = Zif::SimpleLayer.new(self, name, @z, render_only_visible, clear_sprites_after_draw)
-      @z += 1
-      return @layers[name]
+      add_layer(name, Zif::SimpleLayer.new(self, name, @z, render_only_visible, clear_sprites_after_draw))
     end
 
     def new_tiled_layer(name, render_only_visible=false)
-      @layers[name] = Zif::TiledLayer.new(self, name, @z, render_only_visible)
-      @z += 1
-      return @layers[name]
+      add_layer(name, Zif::TiledLayer.new(self, name, @z, render_only_visible))
+    end
+
+    def new_active_tiled_layer(name)
+      add_layer(name, Zif::ActiveTiledLayer.new(self, name, @z))
     end
 
     def new_bitmasked_tiled_layer(name, render_only_visible=false)
-      @layers[name] = Zif::BitmaskedTiledLayer.new(self, name, @z, render_only_visible)
-      @z += 1
-      return @layers[name]
+      add_layer(name, Zif::BitmaskedTiledLayer.new(self, name, @z, render_only_visible))
+    end
+
+    def new_active_bitmasked_tiled_layer(name)
+      add_layer(name, Zif::ActiveBitmaskedTiledLayer.new(self, name, @z))
     end
 
     def max_width

--- a/app/lib/zif/layered_tile_map/simple_layer.rb
+++ b/app/lib/zif/layered_tile_map/simple_layer.rb
@@ -19,7 +19,18 @@ module Zif
     end
 
     def reinitialize_sprites
-      self.source_sprites = []
+      @source_sprites = []
+      @sprites = []
+    end
+
+    def add_positioned_sprite(logical_x, logical_y, sprite)
+      # puts "SimpleLayer#add_positioned_sprite: #{logical_x} #{logical_y}"
+      @source_sprites << position_sprite(sprite, logical_x, logical_y)
+    end
+
+    # This only removes it from the data layer, you'll need to redraw to remove it visually
+    def remove_sprite(sprite)
+      @source_sprites.delete(sprite)
     end
 
     def rerender

--- a/app/lib/zif/layered_tile_map/simple_layer.rb
+++ b/app/lib/zif/layered_tile_map/simple_layer.rb
@@ -19,7 +19,7 @@ module Zif
     end
 
     def reinitialize_sprites
-      @source_sprites = []
+      self.source_sprites = []
     end
 
     def rerender
@@ -31,7 +31,7 @@ module Zif
         @sprites = if @render_only_visible
                      visible_sprites.to_a
                    else
-                     @source_sprites
+                     source_sprites
                    end
 
         redraw

--- a/app/lib/zif/layered_tile_map/tileable.rb
+++ b/app/lib/zif/layered_tile_map/tileable.rb
@@ -2,56 +2,40 @@ module Zif
   # Functionality shared between TiledLayer & BitmaskedTiledLayer
   # Modifies the layer to be based on a 2d source_sprites array.
   module Tileable
-    attr_accessor :source_sprites
+    def tile_pos_to_sprite_index(logical_y, logical_x)
+      (logical_y*@map.logical_width)+logical_x
+    end
 
-    # Because @source_sprites is a 2d array, and the CompoundSprite version of this class expects to be able to iterate
-    # over a 1d @sprites array, we need to update the references in @sprites whenever we change @source_sprites
-    # I thought about implementing this as some magic on source_sprites, but [][] is hard to fake out. PR welcome
-    def sync_sprites_at(logical_x, logical_y)
-      puts "a: #{logical_y} #{logical_x} #{@sprites[0].class.to_s} #{@source_sprites[logical_y].class.to_s}"
-      sprite = @source_sprites[logical_y][logical_x]
-      puts "b: #{sprite.class.to_s}: #{(logical_y*@map.logical_width)+logical_x}"
-      @sprites[(logical_y*@map.logical_width)+logical_x] = sprite
-      puts "c: #{@sprites.length} #{@sprites[0].class.to_s} #{@source_sprites[logical_y].class.to_s}"
-      raise "dammit" if @sprites[0].is_a?(Array)
+    def tile(logical_y, logical_x)
+      @sprites[tile_pos_to_sprite_index(logical_y, logical_x)]
     end
 
     def reinitialize_sprites
-      puts "#{@layer_name}: Tileable#reinitialize_sprites #{@map.logical_height} #{@map.logical_width}"
-      @source_sprites = Array.new(@map.logical_height) { Array.new(@map.logical_width) }
-      # @sprites = Array.new(@map.logical_height * @map.logical_width)
-      @sprites = []
-      @source_sprites.each_with_index do |col, c_idx|
-        col.each_with_index do |row, r_idx|
-          @sprites << row
-        end
-      end
-      # @sprites = @source_sprites.flatten
-      puts "="*80
-      puts "i: #{@map.logical_height*@map.logical_width} #{@sprites.length}"
-      puts "j: #{@sprites[0].class.to_s} #{@source_sprites[0].class.to_s}"
-      raise "dammit" if @sprites[0].is_a?(Array)
+      super
+      # puts "#{@layer_name}: Tileable#reinitialize_sprites #{@map.logical_height} #{@map.logical_width}"
+      @sprites = Array.new(@map.logical_height * @map.logical_width)
     end
 
-    def add_positioned_sprite(logical_x, logical_y, tile_sprite_proto)
-      puts "#{@layer_name}: Tileable#add_positioned_sprite #{logical_x} #{logical_y}"
-      puts "  #{source_sprites.nil?} #{source_sprites[logical_y].class.to_s}"
-      self.source_sprites[logical_y][logical_x] = position_sprite(tile_sprite_proto, logical_x, logical_y)
-      sync_sprites_at(logical_x, logical_y)
-        puts "-"*80
-        puts @source_sprites[0].class.to_s
+    def add_positioned_sprite(logical_x, logical_y, sprite)
+      # puts "#{@layer_name}: Tileable#add_positioned_sprite #{logical_x} #{logical_y}"
+      # puts "#{@sprites.class.to_s}"
+      @sprites[tile_pos_to_sprite_index(logical_y, logical_x)] = position_sprite(sprite, logical_x, logical_y)
     end
 
     def remove_positioned_sprite(sprite)
       x = sprite.logical_x
       y = sprite.logical_y
-      self.source_sprites[y][x] = nil
-      sync_sprites_at(x, y)
+      @sprites[tile_pos_to_sprite_index(y, x)] = nil
+    end
+
+    def remove_tile(logical_y, logical_x)
+      @sprites[tile_pos_to_sprite_index(logical_y, logical_x)] = nil
     end
 
     # This returns an enumerator which can be used to iterate over only the tiles which are visible.
     # Only for layers which have allocated_tiles!
     def visible_sprites(given_rect=nil)
+      # puts "Tileable#visible_sprites: #{@layer_name} '#{given_rect}'"
       if given_rect.nil?
         containing_sprite.view_actual_size! unless containing_sprite.source_is_set?
         compare_left   = containing_sprite.source_x
@@ -65,8 +49,8 @@ module Zif
         compare_h      = given_rect.h
       end
 
-      logical_x = compare_left.fdiv(@map.tile_width)
-      logical_y = compare_bottom.fdiv(@map.tile_height)
+      logical_x = compare_left.idiv(@map.tile_width)
+      logical_y = compare_bottom.idiv(@map.tile_height)
       x_range   = compare_w.fdiv(@map.tile_width)
       y_range   = compare_h.fdiv(@map.tile_height)
 
@@ -86,15 +70,19 @@ module Zif
       starting_b = [logical_y, 0].max
       a = starting_a
       b = starting_b
+
+      # puts " -> #{logical_x} #{logical_y} #{x_range} #{y_range} #{max_y} #{max_x} #{starting_a} #{starting_b} "
+
       Enumerator.new do |yielder|
         loop do
-          yielder << source_sprites[b][a] if source_sprites[b][a]
+          next_tile = tile(b, a)
+          yielder << next_tile if next_tile
           r, a = (a + 1).divmod(max_x)
           if r.positive?
             a = starting_a
             b += r
           end
-          break unless source_sprites[b] && b <= max_y
+          break if b > max_y
         end
       end
     end
@@ -104,7 +92,7 @@ module Zif
     end
 
     def exclude_from_serialize
-      %w[source_sprites sprites primitives]
+      %w[sprites primitives]
     end
   end
 end

--- a/app/lib/zif/layered_tile_map/tileable.rb
+++ b/app/lib/zif/layered_tile_map/tileable.rb
@@ -1,0 +1,110 @@
+module Zif
+  # Functionality shared between TiledLayer & BitmaskedTiledLayer
+  # Modifies the layer to be based on a 2d source_sprites array.
+  module Tileable
+    attr_accessor :source_sprites
+
+    # Because @source_sprites is a 2d array, and the CompoundSprite version of this class expects to be able to iterate
+    # over a 1d @sprites array, we need to update the references in @sprites whenever we change @source_sprites
+    # I thought about implementing this as some magic on source_sprites, but [][] is hard to fake out. PR welcome
+    def sync_sprites_at(logical_x, logical_y)
+      puts "a: #{logical_y} #{logical_x} #{@sprites[0].class.to_s} #{@source_sprites[logical_y].class.to_s}"
+      sprite = @source_sprites[logical_y][logical_x]
+      puts "b: #{sprite.class.to_s}: #{(logical_y*@map.logical_width)+logical_x}"
+      @sprites[(logical_y*@map.logical_width)+logical_x] = sprite
+      puts "c: #{@sprites.length} #{@sprites[0].class.to_s} #{@source_sprites[logical_y].class.to_s}"
+      raise "dammit" if @sprites[0].is_a?(Array)
+    end
+
+    def reinitialize_sprites
+      puts "#{@layer_name}: Tileable#reinitialize_sprites #{@map.logical_height} #{@map.logical_width}"
+      @source_sprites = Array.new(@map.logical_height) { Array.new(@map.logical_width) }
+      # @sprites = Array.new(@map.logical_height * @map.logical_width)
+      @sprites = []
+      @source_sprites.each_with_index do |col, c_idx|
+        col.each_with_index do |row, r_idx|
+          @sprites << row
+        end
+      end
+      # @sprites = @source_sprites.flatten
+      puts "="*80
+      puts "i: #{@map.logical_height*@map.logical_width} #{@sprites.length}"
+      puts "j: #{@sprites[0].class.to_s} #{@source_sprites[0].class.to_s}"
+      raise "dammit" if @sprites[0].is_a?(Array)
+    end
+
+    def add_positioned_sprite(logical_x, logical_y, tile_sprite_proto)
+      puts "#{@layer_name}: Tileable#add_positioned_sprite #{logical_x} #{logical_y}"
+      puts "  #{source_sprites.nil?} #{source_sprites[logical_y].class.to_s}"
+      self.source_sprites[logical_y][logical_x] = position_sprite(tile_sprite_proto, logical_x, logical_y)
+      sync_sprites_at(logical_x, logical_y)
+        puts "-"*80
+        puts @source_sprites[0].class.to_s
+    end
+
+    def remove_positioned_sprite(sprite)
+      x = sprite.logical_x
+      y = sprite.logical_y
+      self.source_sprites[y][x] = nil
+      sync_sprites_at(x, y)
+    end
+
+    # This returns an enumerator which can be used to iterate over only the tiles which are visible.
+    # Only for layers which have allocated_tiles!
+    def visible_sprites(given_rect=nil)
+      if given_rect.nil?
+        containing_sprite.view_actual_size! unless containing_sprite.source_is_set?
+        compare_left   = containing_sprite.source_x
+        compare_bottom = containing_sprite.source_y
+        compare_w      = containing_sprite.source_w
+        compare_h      = containing_sprite.source_h
+      else
+        compare_left   = given_rect.x
+        compare_bottom = given_rect.y
+        compare_w      = given_rect.w
+        compare_h      = given_rect.h
+      end
+
+      logical_x = compare_left.fdiv(@map.tile_width)
+      logical_y = compare_bottom.fdiv(@map.tile_height)
+      x_range   = compare_w.fdiv(@map.tile_width)
+      y_range   = compare_h.fdiv(@map.tile_height)
+
+      max_y = [logical_y + y_range.ceil + 1, @map.logical_height].min
+      max_x = [logical_x + x_range.ceil + 1, @map.logical_width].min
+
+      # This enumerator is basically the equivalent of:
+      #
+      # @floor_tiles[logical_y..max_y].map do |x_tiles|
+      #   x_tiles[logical_x..max_x]
+      # end.flatten.to_enum
+      #
+      # The benefit of doing this instead is that we avoid some extraneous iteration and allocation if we call
+      # #visible_tiles more than once per tick.  This definitely feels faster, but I haven't benchmarked.
+
+      starting_a = [logical_x, 0].max
+      starting_b = [logical_y, 0].max
+      a = starting_a
+      b = starting_b
+      Enumerator.new do |yielder|
+        loop do
+          yielder << source_sprites[b][a] if source_sprites[b][a]
+          r, a = (a + 1).divmod(max_x)
+          if r.positive?
+            a = starting_a
+            b += r
+          end
+          break unless source_sprites[b] && b <= max_y
+        end
+      end
+    end
+
+    def intersecting_sprites(compare_left, compare_bottom, compare_right, compare_top)
+      visible_sprites([compare_left, compare_bottom, compare_right - compare_left, compare_top - compare_bottom])
+    end
+
+    def exclude_from_serialize
+      %w[source_sprites sprites primitives]
+    end
+  end
+end

--- a/app/lib/zif/layered_tile_map/tiled_layer.rb
+++ b/app/lib/zif/layered_tile_map/tiled_layer.rb
@@ -3,76 +3,10 @@ module Zif
   # A layer consisting of an initially empty 2D array of sprites
   # Overrides to SimpleLayer which understand this 2D array
   class TiledLayer < SimpleLayer
-    def reinitialize_sprites
-      @source_sprites = Array.new(@map.logical_height) { Array.new(@map.logical_width) }
-    end
+    include Tileable
+  end
 
-    # This returns an enumerator which can be used to iterate over only the tiles which are visible.
-    # Only for layers which have allocated_tiles!
-    def visible_sprites(given_rect=nil)
-      if given_rect.nil?
-        containing_sprite.view_actual_size! unless containing_sprite.source_is_set?
-        compare_left   = containing_sprite.source_x
-        compare_bottom = containing_sprite.source_y
-        compare_w      = containing_sprite.source_w
-        compare_h      = containing_sprite.source_h
-      else
-        compare_left   = given_rect.x
-        compare_bottom = given_rect.y
-        compare_w      = given_rect.w
-        compare_h      = given_rect.h
-      end
-
-      logical_x = compare_left.fdiv(@map.tile_width)
-      logical_y = compare_bottom.fdiv(@map.tile_height)
-      x_range   = compare_w.fdiv(@map.tile_width)
-      y_range   = compare_h.fdiv(@map.tile_height)
-
-      max_y = [logical_y + y_range.ceil + 1, @map.logical_height].min
-      max_x = [logical_x + x_range.ceil + 1, @map.logical_width].min
-
-      # This enumerator is basically the equivalent of:
-      #
-      # @floor_tiles[logical_y..max_y].map do |x_tiles|
-      #   x_tiles[logical_x..max_x]
-      # end.flatten.to_enum
-      #
-      # The benefit of doing this instead is that we avoid some extraneous iteration and allocation if we call
-      # #visible_tiles more than once per tick.  This definitely feels faster, but I haven't benchmarked.
-
-      starting_a = [logical_x, 0].max
-      starting_b = [logical_y, 0].max
-      a = starting_a
-      b = starting_b
-      Enumerator.new do |yielder|
-        loop do
-          yielder << @source_sprites[b][a] if @source_sprites[b][a]
-          r, a = (a + 1).divmod(max_x)
-          if r.positive?
-            a = starting_a
-            b += r
-          end
-          break unless @source_sprites[b] && b <= max_y
-        end
-      end
-    end
-
-    def intersecting_sprites(compare_left, compare_bottom, compare_right, compare_top)
-      visible_sprites([compare_left, compare_bottom, compare_right - compare_left, compare_top - compare_bottom])
-    end
-
-    def add_positioned_sprite(logical_x, logical_y, tile_sprite_proto)
-      @source_sprites[logical_y][logical_x] = position_sprite(tile_sprite_proto, logical_x, logical_y)
-    end
-
-    def remove_positioned_sprite(sprite)
-      x = sprite.logical_x
-      y = sprite.logical_y
-      @source_sprites[y][x] = nil
-    end
-
-    def exclude_from_serialize
-      %w[source_sprites sprites primitives]
-    end
+  class ActiveTiledLayer < ActiveLayer
+    include Tileable
   end
 end

--- a/app/lib/zif/services/action_service.rb
+++ b/app/lib/zif/services/action_service.rb
@@ -35,7 +35,18 @@ module Zif
     end
 
     def run_all_actions
-      @actionables.each(&:perform_actions)
+      actionables_count = @actionables&.length
+
+      return false unless actionables_count&.positive?
+
+      # Avoid blocks here.
+      idx = 0
+      while idx < actionables_count
+        @actionables[idx].perform_actions
+        idx += 1
+      end
+
+      true
     end
   end
 end

--- a/app/lib/zif/sprites/compound_sprite.rb
+++ b/app/lib/zif/sprites/compound_sprite.rb
@@ -34,10 +34,11 @@ module Zif
       #             Therefore, anything even *partially* visible will be *fully* drawn.
 
       $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: Sprite drawing begin")
+      # puts "CompoundSprite(#{@name})#draw_override: Sprite drawing begin"
 
       # Throwback to the days before Enumerable, for performance reasons
       cur_sprite_idx = 0
-      total_sprite_length = sprites.length
+      total_sprite_length = sprites.count
       while cur_sprite_idx < total_sprite_length
         sprite = @sprites[cur_sprite_idx]
         cur_sprite_idx += 1
@@ -57,10 +58,10 @@ module Zif
         )
 
         ffi_draw.draw_sprite_3(
-          ((x - @source_x) * x_zoom).round + @x,
-          ((y - @source_y) * y_zoom).round + @y,
-          (w * x_zoom).round,
-          (h * y_zoom).round,
+          (x - @source_x) * x_zoom + @x,
+          (y - @source_y) * y_zoom + @y,
+          w * x_zoom,
+          h * y_zoom,
           sprite.path.s_or_default,
           sprite.angle,
           sprite.a,
@@ -79,6 +80,7 @@ module Zif
         )
       end
       $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: Sprite drawing complete")
+      # puts "CompoundSprite(#{@name})#draw_override: Sprite drawing complete"
 
       labels.each do |label|
         # TODO: Skip if not in visible window

--- a/app/lib/zif/sprites/compound_sprite.rb
+++ b/app/lib/zif/sprites/compound_sprite.rb
@@ -9,19 +9,6 @@ module Zif
       @labels      = []
     end
 
-    # You want to use this, unless you're trying to zoom/pan.
-    # These attrs need to be set before we can display component sprites.
-    def view_actual_size!
-      @source_x = 0
-      @source_y = 0
-      @source_w = @w
-      @source_h = @h
-    end
-
-    def source_is_set?
-      !(@source_x.nil? || @source_y.nil? || @source_w.nil? || @source_h.nil?)
-    end
-
     def source_rect
       view_actual_size! unless source_is_set?
       super
@@ -62,16 +49,18 @@ module Zif
         h = sprite.h
 
         # This performs a little better than calling intersect_rect?
-        next if x + w < @source_x
-        next if x > cur_source_right
-        next if y + h < @source_y
-        next if y > cur_source_top
+        next if (
+          (x     > cur_source_right) ||
+          (y     > cur_source_top)   ||
+          (x + w < @source_x)        ||
+          (y + h < @source_y)
+        )
 
         ffi_draw.draw_sprite_3(
-          ((x - @source_x) * x_zoom) + @x,
-          ((y - @source_y) * y_zoom) + @y,
-          w * x_zoom,
-          h * y_zoom,
+          ((x - @source_x) * x_zoom).round + @x,
+          ((y - @source_y) * y_zoom).round + @y,
+          (w * x_zoom).round,
+          (h * y_zoom).round,
           sprite.path.s_or_default,
           sprite.angle,
           sprite.a,

--- a/app/lib/zif/sprites/compound_sprite.rb
+++ b/app/lib/zif/sprites/compound_sprite.rb
@@ -18,24 +18,25 @@ module Zif
       @source_h = @h
     end
 
+    def source_is_set?
+      !(@source_x.nil? || @source_y.nil? || @source_w.nil? || @source_h.nil?)
+    end
+
     def source_rect
-      cur_rect = super
-
-      # The source attrs must be set to something... assume full size.
-      if cur_rect.any?(&:nil?)
-        view_actual_size!
-        cur_rect = super
-      end
-
-      cur_rect
+      view_actual_size! unless source_is_set?
+      super
     end
 
     def draw_override(ffi_draw)
+      $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: begin")
       # Treat an alpha setting of 0 as an indication that it should be hidden, to match Sprite behavior
       return if @a.zero?
 
+      view_actual_size! unless source_is_set?
+
       x_zoom, y_zoom = zoom_factor
-      cur_source_rect = source_rect
+      cur_source_right = @source_x + @source_w
+      cur_source_top   = @source_y + @source_h
 
       # Since this "sprite" itself won't actually be drawn, we can use the positioning attributes to control the
       # contained sprites.
@@ -45,16 +46,26 @@ module Zif
       # source_w/h: extent of visible window.  Unfortunately we can't clip sprites in half using this method.
       #             Therefore, anything even *partially* visible will be *fully* drawn.
 
-      # puts "#{@name}: Begin drawing"
-      sprites.each do |sprite|
+      $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: Sprite drawing begin")
+
+      # Throwback to the days before Enumerable, for performance reasons
+      cur_sprite_idx = 0
+      total_sprite_length = sprites.length
+      while cur_sprite_idx < total_sprite_length
+        sprite = @sprites[cur_sprite_idx]
+        cur_sprite_idx += 1
         next if sprite.nil?
 
-        cur_rect = sprite.rect
+        x = sprite.x
+        y = sprite.y
+        w = sprite.w
+        h = sprite.h
 
-        # puts "#{@name}: #{sprite.name} #{cur_rect} #{cur_source_rect}"
-        next unless cur_rect.intersect_rect?(cur_source_rect, 0.1)
-
-        x, y, w, h = cur_rect
+        # This performs a little better than calling intersect_rect?
+        next if x + w < @source_x
+        next if x > cur_source_right
+        next if y + h < @source_y
+        next if y > cur_source_top
 
         ffi_draw.draw_sprite_3(
           ((x - @source_x) * x_zoom) + @x,
@@ -78,8 +89,8 @@ module Zif
           sprite.source_h
         )
       end
+      $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: Sprite drawing complete")
 
-      # puts "#{@name}: Drew sprites"
       labels.each do |label|
         # TODO: Skip if not in visible window
         ffi_draw.draw_label(
@@ -95,7 +106,7 @@ module Zif
           label.font.s_or_default(nil)
         )
       end
-      # puts "#{@name}: Drew labels"
+      $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: Label drawing complete")
     end
   end
 end

--- a/app/lib/zif/sprites/compound_sprite.rb
+++ b/app/lib/zif/sprites/compound_sprite.rb
@@ -15,7 +15,7 @@ module Zif
     end
 
     def draw_override(ffi_draw)
-      $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: begin")
+      # $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: begin")
       # Treat an alpha setting of 0 as an indication that it should be hidden, to match Sprite behavior
       return if @a.zero?
 
@@ -33,7 +33,7 @@ module Zif
       # source_w/h: extent of visible window.  Unfortunately we can't clip sprites in half using this method.
       #             Therefore, anything even *partially* visible will be *fully* drawn.
 
-      $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: Sprite drawing begin")
+      # $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: Sprite drawing begin")
       # puts "CompoundSprite(#{@name})#draw_override: Sprite drawing begin"
 
       # Throwback to the days before Enumerable, for performance reasons
@@ -79,7 +79,7 @@ module Zif
           sprite.source_h
         )
       end
-      $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: Sprite drawing complete")
+      # $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: Sprite drawing complete")
       # puts "CompoundSprite(#{@name})#draw_override: Sprite drawing complete"
 
       labels.each do |label|
@@ -97,7 +97,7 @@ module Zif
           label.font.s_or_default(nil)
         )
       end
-      $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: Label drawing complete")
+      # $services&.named(:tracer)&.mark("CompoundSprite(#{@name})#draw_override: Label drawing complete")
     end
   end
 end

--- a/app/lib/zif/sprites/render_target.rb
+++ b/app/lib/zif/sprites/render_target.rb
@@ -56,7 +56,7 @@ module Zif
     # This is the only way to force any changes to the RT.  You must call this any time you want to redraw @sprites, etc
     def redraw
       # puts "RenderTarget#redraw: #{@name} #{@width} #{@height} #{@sprites.length} sprites, #{@labels.length} labels"
-      # $services[:tracer].mark("#redraw: #{@name} Begin")
+      # $services&.named(:tracer)&..mark("#redraw: #{@name} Begin")
       targ = $gtk.args.outputs[@name]
       targ.width  = @width
       targ.height = @height
@@ -67,7 +67,7 @@ module Zif
       targ.primitives << @primitives if @primitives&.any?
       targ.sprites    << @sprites    if @sprites&.any?
       targ.labels     << @labels     if @labels&.any?
-      # $services[:tracer].mark("#redraw: #{@name} Complete")
+      # $services&.named(:tracer)&..mark("#redraw: #{@name} Complete")
     end
 
     def clicked?(point, kind=:up)
@@ -141,23 +141,23 @@ module Zif
     end
 
     def redraw_from_buffer(sprites=[], cut_rect=nil, additional_containing_sprites=[])
-      $services[:tracer].mark("RenderTarget#redraw_from_buffer: #{@name} Begin")
+      # $services&.named(:tracer)&..mark("RenderTarget#redraw_from_buffer: #{@name} Begin")
       source_buffer_sprites = cut_rect ? cut_containing_sprites(cut_rect) : [full_containing_sprite]
 
       set_inactive_buffer_name unless @inactive_buffer_name
       # puts "RenderTarget#redraw_from_buffer: name: #{@name}, inactive: #{@inactive_buffer_name}"
       # puts "RenderTarget#redraw_from_buffer: cut_rect: #{cut_rect}, source: #{source_buffer_sprites.inspect}"
 
-      $services[:tracer].mark("RenderTarget#redraw_from_buffer: #{@name} Sprites")
+      # $services&.named(:tracer)&..mark("RenderTarget#redraw_from_buffer: #{@name} Sprites")
       targ = $gtk.args.outputs[@inactive_buffer_name]
       targ.width  = @width
       targ.height = @height
-      $services[:tracer].mark("RenderTarget#redraw_from_buffer: #{@name} HW")
+      # $services&.named(:tracer)&..mark("RenderTarget#redraw_from_buffer: #{@name} HW")
       targ.background_color = @bg_color
       targ.sprites << [source_buffer_sprites] + sprites
 
       switch_buffer(additional_containing_sprites)
-      $services[:tracer].mark("RenderTarget#redraw_from_buffer: #{@name} End")
+      # $services&.named(:tracer)&..mark("RenderTarget#redraw_from_buffer: #{@name} End")
     end
 
     # Expects xywh

--- a/app/lib/zif/sprites/render_target.rb
+++ b/app/lib/zif/sprites/render_target.rb
@@ -141,23 +141,23 @@ module Zif
     end
 
     def redraw_from_buffer(sprites=[], cut_rect=nil, additional_containing_sprites=[])
-      $services[:tracer].mark("#redraw_from_buffer: #{@name} Begin")
+      $services[:tracer].mark("RenderTarget#redraw_from_buffer: #{@name} Begin")
       source_buffer_sprites = cut_rect ? cut_containing_sprites(cut_rect) : [full_containing_sprite]
 
       set_inactive_buffer_name unless @inactive_buffer_name
-      # puts "#redraw_from_buffer: name: #{@name}, inactive: #{@inactive_buffer_name}"
-      # puts "#redraw_from_buffer: cut_rect: #{cut_rect}, source: #{source_buffer_sprites.inspect}"
+      # puts "RenderTarget#redraw_from_buffer: name: #{@name}, inactive: #{@inactive_buffer_name}"
+      # puts "RenderTarget#redraw_from_buffer: cut_rect: #{cut_rect}, source: #{source_buffer_sprites.inspect}"
 
-      $services[:tracer].mark("#redraw_from_buffer: #{@name} Sprites")
+      $services[:tracer].mark("RenderTarget#redraw_from_buffer: #{@name} Sprites")
       targ = $gtk.args.outputs[@inactive_buffer_name]
       targ.width  = @width
       targ.height = @height
-      $services[:tracer].mark("#redraw_from_buffer: #{@name} HW")
+      $services[:tracer].mark("RenderTarget#redraw_from_buffer: #{@name} HW")
       targ.background_color = @bg_color
       targ.sprites << [source_buffer_sprites] + sprites
 
       switch_buffer(additional_containing_sprites)
-      $services[:tracer].mark("#redraw_from_buffer: #{@name} End")
+      $services[:tracer].mark("RenderTarget#redraw_from_buffer: #{@name} End")
     end
 
     # Expects xywh

--- a/app/lib/zif/sprites/serializable.rb
+++ b/app/lib/zif/sprites/serializable.rb
@@ -10,7 +10,8 @@
 #   end
 module Zif
   # A mixin for automatically definining #serialize based on instance vars with setter methods
-  # **DO NOT USE THIS** if you have circular references in ivars (Foo.bar <-> Bar.foo)
+  # If you have circular references in ivars (Foo.bar <-> Bar.foo), make sure one of the classes overrides
+  # #exclude_from_serialize and specifies the attr.
   module Serializable
     def inspect
       serialize.to_s
@@ -31,6 +32,7 @@ module Zif
       attrs
     end
 
+    # Override this method to exclude attrs from serialization / printing
     def exclude_from_serialize
       %w[args] # Too much spam
     end

--- a/app/lib/zif/sprites/sprite.rb
+++ b/app/lib/zif/sprites/sprite.rb
@@ -110,6 +110,8 @@ module Zif
       [(@x + @w.idiv(2)).to_i, (@y + @h.idiv(2)).to_i]
     end
 
+    # Performance tip:
+    # Use the Sprite itself for things like #intersect_rect? rather than creating this array!
     def rect
       [@x, @y, @w, @h]
     end

--- a/app/lib/zif/sprites/sprite.rb
+++ b/app/lib/zif/sprites/sprite.rb
@@ -106,8 +106,16 @@ module Zif
       [@w, @h]
     end
 
+    def center_x
+      (@x + @w.idiv(2)).to_i
+    end
+
+    def center_y
+      (@y + @h.idiv(2)).to_i
+    end
+
     def center
-      [(@x + @w.idiv(2)).to_i, (@y + @h.idiv(2)).to_i]
+      [center_x, center_y]
     end
 
     # Performance tip:
@@ -118,6 +126,19 @@ module Zif
 
     def rect_hash
       Sprite.rect_array_to_hash(rect)
+    end
+
+    # You want to use this, unless you're trying to zoom/pan.
+    # These attrs need to be set before we can display component sprites.
+    def view_actual_size!
+      @source_x = 0
+      @source_y = 0
+      @source_w = @w
+      @source_h = @h
+    end
+
+    def source_is_set?
+      !(@source_x.nil? || @source_y.nil? || @source_w.nil? || @source_h.nil?)
     end
 
     def source_xy

--- a/app/lib/zif/zif.rb
+++ b/app/lib/zif/zif.rb
@@ -91,12 +91,12 @@ module Zif
     die.times.map { rand(sides) + 1 }.inject(0) { |z, memo| memo + z }
   end
 
-  # DEPRECATED - Use Actions instead
-  def self.ease(t, total)
-    Math.sin(((t / total.to_f) * Math::PI) / 2.0)
-  end
-
   def self.random_name(type='unknown')
     "#{type}_#{Kernel.tick_count}_#{rand(100_000)}"
+  end
+
+  # Usually you want to use Actions instead
+  def self.ease(t, total)
+    Math.sin(((t / total.to_f) * Math::PI) / 2.0)
   end
 end

--- a/app/main.rb
+++ b/app/main.rb
@@ -85,6 +85,7 @@ require 'app/avatar.rb'
 class ZifExample < Zif::Game
   def initialize
     super()
+    @services[:tracer].measure_averages = true
     1.upto 4 do |i|
       @services[:sprite_registry].register_basic_sprite("dragon_#{i}", 82, 66)
     end

--- a/app/main.rb
+++ b/app/main.rb
@@ -51,11 +51,13 @@ require 'app/lib/zif/camera.rb'
 
 # Depends on compound_sprite.rb, expects to be initialized with a LayeredTileMap-like @map
 require 'app/lib/zif/layered_tile_map/layerable.rb'
+require 'app/lib/zif/layered_tile_map/tileable.rb'
 require 'app/lib/zif/layered_tile_map/active_layer.rb'
 
 # Depends on render_target.rb, expects to be initialized with a LayeredTileMap-like @map
 require 'app/lib/zif/layered_tile_map/simple_layer.rb'
 require 'app/lib/zif/layered_tile_map/tiled_layer.rb'
+require 'app/lib/zif/layered_tile_map/bitmasked_tiled_layer.rb'
 
 # Depends on simple_layer.rb, tiled_layer.rb, traceable.rb
 require 'app/lib/zif/layered_tile_map/layered_tile_map.rb'

--- a/app/scenes/compound_sprite_test.rb
+++ b/app/scenes/compound_sprite_test.rb
@@ -10,6 +10,7 @@ class CompoundSpriteTest < ZifExampleScene
     @next_scene = :ui_sample
 
     @compound_sprite = Zif::CompoundSprite.new.tap do |s|
+      s.name = "Test Sprite"
       s.x = 100
       s.y = 100
       s.w = 800
@@ -32,7 +33,7 @@ class CompoundSpriteTest < ZifExampleScene
       s.a = 30
     end
 
-    [[0, 50], [100, 150], [0, 250]].each do |pos|
+    @dragons = [[0, 50], [100, 150], [0, 250]].map do |pos|
       dragon = $game.services[:sprite_registry].construct('dragon_1').tap do |s|
         s.name = "dragon_#{pos.inspect}"
         s.x = pos[0]
@@ -72,7 +73,38 @@ class CompoundSpriteTest < ZifExampleScene
 
       dragon.run_animation_sequence(:fly)
 
-      @compound_sprite.sprites << dragon
+      dragon
+    end
+
+    @compound_sprite.sprites += @dragons
+
+    lead_dragon = @dragons[1]
+
+    8000.times do |i|
+      wait, layer = i.divmod(9)
+      pixie = $game.services[:sprite_registry].construct(:white_1).tap do |s|
+        s.x = rand(800)
+        s.y = rand(400)
+        s.w = 10
+        s.h = 10
+        s.source_x = 0
+        s.source_y = 0
+        s.source_w = 10
+        s.source_h = 10
+        s.a = 30
+        s.r, s.g, s.b = Zif.rand_rgb(100, 255)
+      end
+
+      # Start rotating by a time offset
+      # pixie.run(
+      #   pixie.delayed_action(wait.seconds) {
+      #     # Testing
+      #     pixie.x = lead_dragon.x - layer * 40
+      #     pixie.y = lead_dragon.y
+      #   }
+      # )
+
+      @compound_sprite.sprites << pixie
     end
 
     dragon_label = Zif::Label.new('A Thunder of Dragons', 0, 1).tap do |label|
@@ -122,7 +154,7 @@ class CompoundSpriteTest < ZifExampleScene
   def prepare_scene
     super
 
-    @compound_sprite.sprites.each do |dragon|
+    @compound_sprite.sprites.each do |dragon| # and pixies
       $game.services[:action_service].register_actionable(dragon)
     end
     @compound_sprite.labels.each do |dragon_label|
@@ -146,8 +178,8 @@ class CompoundSpriteTest < ZifExampleScene
     @compound_sprite.source_w -= 100 if $gtk.args.inputs.keyboard.key_up.left
 
     # rubocop:disable Layout/LineLength
-    $gtk.args.outputs.labels << { x: 8, y: 100, text: 'Up/Down: Modify source_h.  Right/Left: Modify source_w.', r: 255, g: 255, b: 255, a: 255}
-    $gtk.args.outputs.labels << { x: 8, y: 80, text: "Compund Sprite: #{@compound_sprite.rect} -> #{@compound_sprite.source_rect}.  Zoom #{@compound_sprite.zoom_factor}", r: 255, g: 255, b: 255, a: 255}
+    $gtk.args.outputs.labels << { x: 4, y: 120, text: 'Up/Down: Modify source_h.  Right/Left: Modify source_w.', r: 255, g: 255, b: 255, a: 255}
+    $gtk.args.outputs.labels << { x: 4, y: 100, text: "Compund Sprite: #{@compound_sprite.rect} -> #{@compound_sprite.source_rect}.  Zoom #{@compound_sprite.zoom_factor}", r: 255, g: 255, b: 255, a: 255}
     # rubocop:enable Layout/LineLength
 
     mark('#perform_tick: Finished')

--- a/app/scenes/compound_sprite_test.rb
+++ b/app/scenes/compound_sprite_test.rb
@@ -80,29 +80,27 @@ class CompoundSpriteTest < ZifExampleScene
 
     lead_dragon = @dragons[1]
 
-    8000.times do |i|
-      wait, layer = i.divmod(9)
+    50.times do |i|
+      _wait, layer = i.divmod(10)
       pixie = $game.services[:sprite_registry].construct(:white_1).tap do |s|
-        s.x = rand(800)
-        s.y = rand(400)
+        s.x = lead_dragon.x
+        s.y = lead_dragon.y
         s.w = 10
         s.h = 10
         s.source_x = 0
         s.source_y = 0
         s.source_w = 10
         s.source_h = 10
-        s.a = 30
+        s.a = 0
         s.r, s.g, s.b = Zif.rand_rgb(100, 255)
       end
 
-      # Start rotating by a time offset
-      # pixie.run(
-      #   pixie.delayed_action(wait.seconds) {
-      #     # Testing
-      #     pixie.x = lead_dragon.x - layer * 40
-      #     pixie.y = lead_dragon.y
-      #   }
-      # )
+      # Start spraying
+      pixie.run(
+        pixie.delayed_action(rand.seconds) {
+          pixie_spray(pixie, layer)
+        }
+      )
 
       @compound_sprite.sprites << pixie
     end
@@ -184,5 +182,21 @@ class CompoundSpriteTest < ZifExampleScene
 
     mark('#perform_tick: Finished')
     super
+  end
+
+  def pixie_spray(pix, layer)
+    idx = rand(3)
+    dir = @dragons[idx].flip_horizontally ? 1 : -1
+
+    pix.x = @dragons[idx].center_x + (5 * layer) * dir
+    pix.y = @dragons[idx].center_y - 10
+    pix.a = 50
+    pix.run(pix.new_action({x: pix.x + ((rand(100) + 20) * dir)}, 2.seconds, :smooth_stop5))
+    pix.run(pix.new_action({y: pix.y + Zif.relative_rand(50)},   2.seconds, :smooth_stop5))
+    pix.run(
+      pix.fade_out(rand.seconds) {
+        pixie_spray(pix, layer)
+      }
+    )
   end
 end

--- a/app/scenes/ui_sample.rb
+++ b/app/scenes/ui_sample.rb
@@ -167,6 +167,7 @@ class UISample < ZifExampleScene
       @glass_label,
       @prog_label,
       @button_label,
+      @metal_label,
       {
         x:    600,
         y:    320,
@@ -230,6 +231,7 @@ class UISample < ZifExampleScene
   end
 
   def perform_tick
+    mark('#perform_tick: begin')
     $gtk.args.outputs.background_color = [0, 0, 0, 0]
 
     change_color if color_should_change?
@@ -239,7 +241,11 @@ class UISample < ZifExampleScene
     update_progress_bar
     update_interactable_button
 
+
+    mark('#perform_tick: finished updates')
     finished = super
+
+    mark('#perform_tick: finished super')
     return finished if finished
 
     @force_next_scene ||= @load_next_scene_next_tick # rubocop:disable Naming/MemoizedInstanceVariableName
@@ -259,6 +265,7 @@ class UISample < ZifExampleScene
     else
       @cutout.hide
     end
+    mark('#update_metal_panel: complete')
   end
 
   def update_glass_panel
@@ -266,6 +273,7 @@ class UISample < ZifExampleScene
     cuts = ('%04b' % (($gtk.args.tick_count / 60) % 16)).chars.map { |bit| bit == '1' }
     @glass.change_cuts(cuts)
     @glass_label.text = "Glass panel cuts: #{@glass.cuts}"
+    mark('#update_glass_panel: complete')
   end
 
   def update_progress_bar
@@ -278,6 +286,7 @@ class UISample < ZifExampleScene
     @prog.view_actual_size!
 
     @prog_label.text = "Progress bar: width #{cur_progress_width}, progress #{(cur_progress * 100).round}%"
+    mark('#update_progress_bar: complete')
   end
 
   def update_interactable_button
@@ -285,5 +294,6 @@ class UISample < ZifExampleScene
     label_text = "Buttons.  #{"#{@counter}/10 " if @counter.positive?}"
     label_text += (@button.is_pressed ? "It's pressed!" : 'Press one.').to_s
     @button_label.text = label_text
+    mark('#update_interactable_button: complete')
   end
 end

--- a/app/scenes/world.rb
+++ b/app/scenes/world.rb
@@ -25,7 +25,7 @@ class World < ZifExampleScene
       @map.max_height
     )
 
-    @map.layers[:avatar].source_sprites = [@avatar]
+    @map.layers[:avatar].sprites << @avatar
 
     @ready = false
     @progress = Hash.new(0)

--- a/app/scenes/world.rb
+++ b/app/scenes/world.rb
@@ -12,7 +12,6 @@ class World < ZifExampleScene
     @map = Zif::LayeredTileMap.new('map', 64, 64, 50, 50)
     @map.new_tiled_layer(:tiles)
     @map.new_active_layer(:avatar)
-    @map.layers[:avatar].should_render = true
     mark('#initialize: Map + layers created')
     @map.force_refresh
     @map.layers[:tiles].should_render = false
@@ -34,10 +33,10 @@ class World < ZifExampleScene
     puts "World#initialize: Initializing #{@map.logical_width}x#{@map.logical_height}"
     puts "  =#{@finished_at[:tiles] + 1} Tiles"
 
-    mark('#initialize: Nearly finished')
+    mark_and_print('#initialize: Nearly finished')
     initialize_tiles
 
-    mark('#initialize: Tiles initialized')
+    mark_and_print('#initialize: Tiles initialized')
   end
 
   # For loading bar
@@ -49,6 +48,7 @@ class World < ZifExampleScene
   # So this is a method for loading which is designed to prevent this and allow us to show a loading bar.
   # The idea is that we run this once per tick, several times until initialization is finished.
   def initialize_tiles
+    mark_and_print('#initialize_tiles: Begin')
     return if @ready
 
     %i[tiles].each do |kind| # stuff
@@ -129,7 +129,7 @@ class World < ZifExampleScene
 
     $gtk.args.outputs.static_sprites << @camera.layers
     # $gtk.args.outputs.static_labels  << @hud_labels
-    # puts "World#finish_initialization: Initialized World"
+    puts "World#finish_initialization: Initialized World"
   end
 
   def perform_tick
@@ -165,10 +165,12 @@ class World < ZifExampleScene
   end
 
   def prepare_scene
+    mark_and_print('#prepare_scene: Begin')
     super
     finish_initialization if @ready && @camera.nil?
 
     @avatar.run_animation_sequence(:fly)
+    mark_and_print('#prepare_scene: Complete')
   end
 
   # rubocop:disable Layout/LineLength

--- a/app/scenes/world_loader.rb
+++ b/app/scenes/world_loader.rb
@@ -50,6 +50,7 @@ class WorldLoader < Zif::Scene
   end
 
   def perform_tick
+    mark_and_print('#perform_tick: Begin')
     $gtk.args.outputs.background_color = [0, 0, 0, 0]
 
     @ready = @world.ready # Need to offset this by 1 tick to fix the progress bar at the end
@@ -75,6 +76,8 @@ class WorldLoader < Zif::Scene
     $gtk.args.outputs.labels << { x: 8, y: 720 - 28, text: "#{tracer&.last_tick_ms} #{$gtk.args.gtk.current_framerate}fps" }.merge(color)
     $gtk.args.outputs.labels << { x: 8, y: 60, text: "Last slowest mark: #{tracer&.slowest_mark}" }.merge(color)
     # rubocop:enable Layout/LineLength
+
+    mark_and_print('#perform_tick: Complete')
 
     # Returning the other Scene instance so the Game knows to switch scenes.  Demonstrating an automatic scene switch
     return @world if @ready

--- a/app/scenes/world_loader.rb
+++ b/app/scenes/world_loader.rb
@@ -42,6 +42,7 @@ class WorldLoader < Zif::Scene
   end
 
   def prepare_scene
+    tracer.clear_averages
     $game.services[:action_service].reset_actionables
     $game.services[:input_service].reset
     $gtk.args.outputs.static_sprites.clear

--- a/app/scenes/zif_example_scene.rb
+++ b/app/scenes/zif_example_scene.rb
@@ -16,12 +16,17 @@ class ZifExampleScene < Zif::Scene
     # You can also do this when a scene is being changed away from, using the #unload_scene method.
     $game.services[:action_service].reset_actionables
     $game.services[:input_service].reset
+    tracer.clear_averages
     $gtk.args.outputs.static_sprites.clear
     $gtk.args.outputs.static_labels.clear
   end
 
   def perform_tick
     display_context_labels
+
+    if $gtk.args.inputs.keyboard.key_up.delete
+      $game.services[:tracer].clear_averages
+    end
 
     if $gtk.args.inputs.keyboard.key_up.pageup
       @pause_timer = !@pause_timer
@@ -38,9 +43,11 @@ class ZifExampleScene < Zif::Scene
   # rubocop:disable Layout/LineLength
   def display_context_labels
     color = {r: 255, g: 255, b: 255, a: 255}
-    $gtk.args.outputs.labels << { x: 8, y: 720 - 8, text: "#{self.class.name}.  Press spacebar to transition to #{@next_scene}, or wait #{@scene_timer} ticks." }.merge(color)
-    $gtk.args.outputs.labels << { x: 8, y: 720 - 28, text: "#{tracer&.last_tick_ms} #{$gtk.args.gtk.current_framerate}fps" }.merge(color)
-    $gtk.args.outputs.labels << { x: 8, y: 60, text: "Last slowest mark: #{tracer&.slowest_mark}" }.merge(color)
+    $gtk.args.outputs.labels << { x: 4, y: 720 - 0, text: "#{self.class.name}.  Press spacebar to transition to #{@next_scene}, or wait #{@scene_timer} ticks." }.merge(color)
+    $gtk.args.outputs.labels << { x: 0, y: 720 - 20, text: "#{tracer&.last_tick_ms} #{$gtk.args.gtk.current_framerate}fps" }.merge(color)
+    $gtk.args.outputs.labels << { x: 4, y: 24, text: "Last slowest mark: #{tracer&.slowest_mark}" }.merge(color)
+    $gtk.args.outputs.labels << { x: 4, y: 44, text: "Max slowest mark: #{tracer&.slowest_max_mark}" }.merge(color)
+    $gtk.args.outputs.labels << { x: 4, y: 64, text: "Avg slowest mark: #{tracer&.slowest_avg_mark}" }.merge(color)
   end
   # rubocop:enable Layout/LineLength
 end


### PR DESCRIPTION
Zif v1.5: Active Tiled Layers
- Reorganized `TiledLayer` and `BitmaskedTiledLayer` to use shared code from modules `Tileable` and `Bitmaskable`
- New classes `ActiveTiledLayer` and `ActiveBitmaskedTiledLayer` inheriting from the `CompoundSprite`-based `ActiveLayer` instead of the `RenderTarget`-based `SimpleLayer`
- Reorganized some methods in Layers a bit to account for the combinations
- Improved performance of `CompoundSprite#draw_override`, `Layerable#visible_sprites`, `ActionService#run_all_actions`
- `TickTraceService` can now be used to measure average execution times for your marked sections of code.  Turn this on by setting `@measure_averages=true` or by passing in `true` as the second argument when initializing.  This uses the text passed to `#mark` as the key to save average times, so please use unchanging strings with `#mark`, otherwise the averages table will become too large.
- Added `Sprite#center_x`, `Sprite#center_y`, `Sprite#source_is_set?`.  Added `Sprite#view_actual_size!` to set the `@source_[x|y|w|h]` values to sensible defaults
- Added `Actionable#delayed_action`: This is a helper which generates a no-op action, so you can set a callback on an Actionable after some time.
- Changed Camera zoom to a set of discrete steps defined by `@zoom_steps` and the current selection index is `@zoom_step`
- Example app:
    - `ZifExampleScene` displays TickTrace averages.  Clear averages with the delete key.
    - Dragons have more sparkles.
