### PR TITLE
Fix import for newer DragonRuby versions

### DIFF
--- a/app/main.rb
+++ b/app/main.rb
@@ -82,25 +82,7 @@ require 'app/scenes/double_buffer_render_test.rb'
 require 'app/scenes/compound_sprite_test.rb'
 
 require 'app/avatar.rb'
-
-# Example usage of a Zif::Game subclass
-class ZifExample < Zif::Game
-  def initialize
-    super()
-    @services[:tracer].measure_averages = true
-    1.upto 4 do |i|
-      @services[:sprite_registry].register_basic_sprite("dragon_#{i}", 82, 66)
-    end
-    @services[:sprite_registry].register_basic_sprite(:transparent_gray_32, 32, 32)
-    @services[:sprite_registry].register_basic_sprite(:white_1, 64, 64)
-
-    register_scene(:ui_sample, UISample)
-    register_scene(:load_world, WorldLoader)
-    register_scene(:load_double_buffer_render_test, DoubleBufferRenderTest)
-    register_scene(:load_compound_sprite_test, CompoundSpriteTest)
-    @scene = UISample.new
-  end
-end
+require 'app/zif_example.rb'
 
 def tick(args)
   if args.tick_count == 2

--- a/app/zif_example.rb
+++ b/app/zif_example.rb
@@ -1,0 +1,18 @@
+# Example usage of a Zif::Game subclass
+class ZifExample < Zif::Game
+  def initialize
+    super()
+    @services[:tracer].measure_averages = true
+    1.upto 4 do |i|
+      @services[:sprite_registry].register_basic_sprite("dragon_#{i}", 82, 66)
+    end
+    @services[:sprite_registry].register_basic_sprite(:transparent_gray_32, 32, 32)
+    @services[:sprite_registry].register_basic_sprite(:white_1, 64, 64)
+
+    register_scene(:ui_sample, UISample)
+    register_scene(:load_world, WorldLoader)
+    register_scene(:load_double_buffer_render_test, DoubleBufferRenderTest)
+    register_scene(:load_compound_sprite_test, CompoundSpriteTest)
+    @scene = UISample.new
+  end
+end


### PR DESCRIPTION
When trying out Zif on my local machine with the latest dragonruby version that uses async requires 
it doesn't work since it doesn't find the `Zif` constant. Moving the example definition to a different file and importing it solves the problem.

Also maybe with the new require in place it's maybe a good time to reorganize and clean up the imports.....

Now only one import line should be enough to use Zif in a project :)