### PR TITLE
Fix default argument for Zif::Actions::Action

### DIFF
--- a/app/lib/zif/actions/action.rb
+++ b/app/lib/zif/actions/action.rb
@@ -134,7 +134,7 @@ module Zif
         node,
         finish,
         follow:   nil,
-        duration: 1.second,
+        duration: 1.seconds,
         easing:   :linear,
         rounding: :round,
         repeat:   1,


### PR DESCRIPTION
There is no `second` method unfortunately...
I checked the remaining repository and this is the only wrong usage