### PR TITLE
Fix unload_scene not called

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,3 +592,29 @@ Some features and things being considered for this library:
 - Ports of DRGTK Sample apps to "Zif style"
 
 If these sound interesting to you, make some noise in the [Dragonruby GTK Discord](https://discord.gg/T8wnRvNn7W) #oss-zif channel.
+
+# Development
+
+## Dependencies
+
+For development you should install the dependencies using Bundler. Ensure you have a recent (> 2.7) version of Ruby installed, and run `bundle install` to install the dependencies.
+
+## Testing
+
+Tests can be found in the `tests` directory.
+
+To execute the tests use the following command:
+
+```sh
+./dragonruby ./path/to/dragonruby-zif --test tests/zif.rb`
+```
+
+## Linting
+
+This project is linted with [RuboCop](https://rubocop.org/).
+
+To execute RuboCop run
+
+```sh
+rubocop -D
+```

--- a/app/lib/zif/game.rb
+++ b/app/lib/zif/game.rb
@@ -143,6 +143,7 @@ module Zif
 
       next_scene = switch_scene(tick_result)
       if next_scene
+        @scene.unload_scene
         next_scene.prepare_scene
         @scene = next_scene
       else

--- a/tests/zif.rb
+++ b/tests/zif.rb
@@ -1,1 +1,2 @@
 require 'tests/zif/sprites.rb'
+require 'tests/zif/game.rb'

--- a/tests/zif/game.rb
+++ b/tests/zif/game.rb
@@ -1,0 +1,1 @@
+require 'tests/zif/game/game_test.rb'

--- a/tests/zif/game/game_test.rb
+++ b/tests/zif/game/game_test.rb
@@ -13,12 +13,15 @@ module GameTest
     end
   end
   SceneB = Class.new(Zif::Scene)
-
-  def test_unloads_scene(_args, assert)
-    scene_a = SceneA.new
-    game = Zif::Game.new.tap { |g| g.scene = scene_a }
-    game.perform_tick
-
-    assert.true! scene_a.unloaded
-  end
 end
+
+def test_unloads_scene(_args, assert)
+  scene_a = GameTest::SceneA.new
+  game = Zif::Game.new.tap { |g| g.scene = scene_a }
+  game.perform_tick
+
+  assert.true! scene_a.unloaded
+end
+
+$gtk.reset 100
+$gtk.log_level = :off

--- a/tests/zif/game_test.rb
+++ b/tests/zif/game_test.rb
@@ -1,0 +1,24 @@
+require 'tests/test_helpers.rb'
+
+module GameTest
+  class SceneA < Zif::Scene
+    attr_reader :unloaded
+
+    def perform_tick
+      SceneB
+    end
+
+    def unload_scene
+      @unloaded = true
+    end
+  end
+  SceneB = Class.new(Zif::Scene)
+
+  def test_unloads_scene(_args, assert)
+    scene_a = SceneA.new
+    game = Zif::Game.new.tap { |g| g.scene = scene_a }
+    game.perform_tick
+
+    assert.true! scene_a.unloaded
+  end
+end


### PR DESCRIPTION
I have fixed the issue of `unload_scene` not being called. More interestingly, I added a test for this and also updated the README to include some information on running the tests and linting. 