### PR TITLE
Improve smaug support

### DIFF
--- a/.smaugignore
+++ b/.smaugignore
@@ -1,4 +1,5 @@
-logs/
-builds/
-exceptions
-Smaug.toml
+*
+!/app/lib/**/*
+!/LICENSE.txt
+!/README.md
+!/Smaug.toml

--- a/Smaug.toml
+++ b/Smaug.toml
@@ -6,49 +6,8 @@ url = "https://danhealy.github.io/dragonruby-zif/"
 
 # Which files do you want to be automatically required from your package.
 requires = [
-  "smaug/zif/app/lib/zif/zif.rb",
-  "smaug/zif/app/lib/zif/serializable.rb",
-  "smaug/zif/app/lib/zif/clickable.rb",
-  "smaug/zif/app/lib/zif/key_pressable.rb",
-  "smaug/zif/app/lib/zif/services/service_group.rb",
-  "smaug/zif/app/lib/zif/services/input_service.rb",
-  "smaug/zif/app/lib/zif/services/tick_trace_service.rb",
-  "smaug/zif/app/lib/zif/traceable.rb",
-  "smaug/zif/app/lib/zif/assignable.rb",
-  "smaug/zif/app/lib/zif/actions/action.rb",
-  "smaug/zif/app/lib/zif/scene.rb",
-  "smaug/zif/app/lib/zif/actions/sequence.rb",
-  "smaug/zif/app/lib/zif/actions/actionable.rb",
-  "smaug/zif/app/lib/zif/ui/label.rb",
-  "smaug/zif/app/lib/zif/ui/input.rb",
-  "smaug/zif/app/lib/zif/actions/animatable.rb",
-  "smaug/zif/app/lib/zif/services/action_service.rb",
-  "smaug/zif/app/lib/zif/sprite.rb",
-  "smaug/zif/app/lib/zif/render_target.rb",
-  "smaug/zif/app/lib/zif/compound_sprite.rb",
-  "smaug/zif/app/lib/zif/services/sprite_registry.rb",
-  "smaug/zif/app/lib/zif/ui/nine_panel_edge.rb",
-  "smaug/zif/app/lib/zif/ui/two_stage_button.rb",
-  "smaug/zif/app/lib/zif/ui/nine_panel.rb",
-  "smaug/zif/app/lib/zif/layers/camera.rb",
-  "smaug/zif/app/lib/zif/layers/layerable.rb",
-  "smaug/zif/app/lib/zif/layers/tileable.rb",
-  "smaug/zif/app/lib/zif/layers/bitmaskable.rb",
-  "smaug/zif/app/lib/zif/layers/active_layer.rb",
-  "smaug/zif/app/lib/zif/layers/active_tiled_layer.rb",
-  "smaug/zif/app/lib/zif/layers/active_bitmasked_tiled_layer.rb",
-  "smaug/zif/app/lib/zif/layers/simple_layer.rb",
-  "smaug/zif/app/lib/zif/layers/tiled_layer.rb",
-  "smaug/zif/app/lib/zif/layers/bitmasked_tiled_layer.rb",
-  "smaug/zif/app/lib/zif/layers/layer_group.rb",
-  "smaug/zif/app/lib/zif/game.rb"
+  "smaug/zif/app/lib/zif/require.rb"
 ]
-
-[package.installs]
-# Example
-#
-# <from> = <to>
-# "lib/library.rb" = "app/lib/library.rb"
 
 [dragonruby]
 version = "5.4"

--- a/app/lib/zif/require.rb
+++ b/app/lib/zif/require.rb
@@ -1,70 +1,70 @@
 # No dependencies
-require 'app/lib/zif/zif.rb'
-require 'app/lib/zif/serializable.rb'
-require 'app/lib/zif/clickable.rb'
-require 'app/lib/zif/key_pressable.rb'
-require 'app/lib/zif/services/service_group.rb'
-require 'app/lib/zif/services/input_service.rb'
-require 'app/lib/zif/services/tick_trace_service.rb'
+require_relative 'zif.rb'
+require_relative 'serializable.rb'
+require_relative 'clickable.rb'
+require_relative 'key_pressable.rb'
+require_relative 'services/service_group.rb'
+require_relative 'services/input_service.rb'
+require_relative 'services/tick_trace_service.rb'
 
 # Expects $services to be services.rb, works with tick_trace_service.rb
-require 'app/lib/zif/traceable.rb'
+require_relative 'traceable.rb'
 
 # Expects to be included in a Sprite subclass
-require 'app/lib/zif/assignable.rb'
+require_relative 'assignable.rb'
 
 # Depends on serializable.rb
-require 'app/lib/zif/actions/action.rb'
-require 'app/lib/zif/scene.rb'
+require_relative 'actions/action.rb'
+require_relative 'scene.rb'
 
 # Depends on serializable.rb, action.rb
-require 'app/lib/zif/actions/sequence.rb'
+require_relative 'actions/sequence.rb'
 
 # Depends on action.rb, sequence.rb
-require 'app/lib/zif/actions/actionable.rb'
+require_relative 'actions/actionable.rb'
 
 # Depends on actionable.rb
-require 'app/lib/zif/ui/label.rb'
-require 'app/lib/zif/ui/input.rb'
+require_relative 'ui/label.rb'
+require_relative 'ui/input.rb'
 
 # Depends on sequence.rb - expects an Actionable class
-require 'app/lib/zif/actions/animatable.rb'
-require 'app/lib/zif/services/action_service.rb'
+require_relative 'actions/animatable.rb'
+require_relative 'services/action_service.rb'
 
 # Depends on serializable.rb, assignable.rb, actionable.rb, animatable.rb
-require 'app/lib/zif/sprite.rb'
+require_relative 'sprite.rb'
 
 # Depends on sprite.rb, zif.rb
-require 'app/lib/zif/render_target.rb'
-require 'app/lib/zif/compound_sprite.rb'
+require_relative 'render_target.rb'
+require_relative 'compound_sprite.rb'
 
 # Depends on sprite.rb
-require 'app/lib/zif/services/sprite_registry.rb'
-require 'app/lib/zif/ui/nine_panel_edge.rb'
+require_relative 'services/sprite_registry.rb'
+require_relative 'ui/nine_panel_edge.rb'
 
 # Depends on compound_sprite.rb
-require 'app/lib/zif/ui/two_stage_button.rb'
-require 'app/lib/zif/ui/nine_panel.rb'
+require_relative 'ui/two_stage_button.rb'
+require_relative 'ui/nine_panel.rb'
 
 # Depends on actionable.rb, zif.rb, - expects $game to be a game.rb
-require 'app/lib/zif/layers/camera.rb'
+require_relative 'layers/camera.rb'
 
 # Depends on compound_sprite.rb, expects to be initialized with a LayerGroup-like @map
-require 'app/lib/zif/layers/layerable.rb'
-require 'app/lib/zif/layers/tileable.rb'
-require 'app/lib/zif/layers/bitmaskable.rb'
-require 'app/lib/zif/layers/active_layer.rb'
-require 'app/lib/zif/layers/active_tiled_layer.rb'
-require 'app/lib/zif/layers/active_bitmasked_tiled_layer.rb'
+require_relative 'layers/layerable.rb'
+require_relative 'layers/tileable.rb'
+require_relative 'layers/bitmaskable.rb'
+require_relative 'layers/active_layer.rb'
+require_relative 'layers/active_tiled_layer.rb'
+require_relative 'layers/active_bitmasked_tiled_layer.rb'
 
 # Depends on render_target.rb, expects to be initialized with a LayerGroup-like @map
-require 'app/lib/zif/layers/simple_layer.rb'
-require 'app/lib/zif/layers/tiled_layer.rb'
-require 'app/lib/zif/layers/bitmasked_tiled_layer.rb'
+require_relative 'layers/simple_layer.rb'
+require_relative 'layers/tiled_layer.rb'
+require_relative 'layers/bitmasked_tiled_layer.rb'
 
 # Depends on simple_layer.rb, tiled_layer.rb, traceable.rb
-require 'app/lib/zif/layers/layer_group.rb'
+require_relative 'layers/layer_group.rb'
 
 # Depends on traceable.rb, services.rb, input_service.rb, tick_trace_service.rb, action_service.rb, sprite_registry.rb,
 #            scene.rb
-require 'app/lib/zif/game.rb'
+require_relative 'game.rb'


### PR DESCRIPTION
## Summary

There are a few issues right now for people who want to use `zif` with a package manager like `smaug`.
This PR addresses those issues and improves the out-the-box support for `smaug` to limit the package size and noise.

## Possible follow-up

This PR attempts to improve things without changing the overall structure of the repo.
However, it's worth pointing out things could be made cleaner with a small refactoring: the actual library code currently lives in `app/lib/zif`, inside the `app` folder which is the example app.

Being a standalone library, `zif` should be able to live on its own and be integrated in DR applications, including the example app. To make this clearer, we could move the `app/lib/zif` folder into a new *project* root-level `/lib` folder and include that into the `app` (which could now be renamed `example_app`).
This change can be done using `git mv` to limit disruptions to existing PRs.

Further changes would be necessary for tests, but that would mostly be it.