### PR TITLE
Fix one-off animations & Allow animation callbacks to run an animation sequence

### DIFF
--- a/app/scenes/ui_sample.rb
+++ b/app/scenes/ui_sample.rb
@@ -108,6 +108,8 @@ module ExampleApp
           @count_progress.progress = @counter / 10.0
 
           @load_next_scene_next_tick = true if @counter >= 10
+
+          @dragon.run_animation_sequence(:coast)
         else
           puts "UISample: Button on_mouse_up, #{point}: mouse outside button. Not pressed."
         end
@@ -189,7 +191,21 @@ module ExampleApp
         paths_and_durations: 1.upto(4).map { |i| ["dragon_#{i}", 4] } + 3.downto(2).map { |i| ["dragon_#{i}", 4] }
       )
 
+      # This is an example of a one-off animation which returns to a looping animation when complete
+      @dragon.new_basic_animation(
+        named:               :coast,
+        paths_and_durations: 1.upto(4).map { |i| ["dragon_#{i}", 12] } + 3.downto(2).map { |i| ["dragon_#{i}", 12] },
+        repeat:              2
+      ) do
+        @dragon.run_animation_sequence(:fly)
+      end
+
       @dragon.run_animation_sequence(:fly)
+
+      @animation_label = {
+        x:    600,
+        y:    200,
+      }.merge(DEBUG_LABEL_COLOR)
 
       # -------------------------------------------------------------------------
       # Info Labels
@@ -205,11 +221,7 @@ module ExampleApp
           y:    320,
           text: 'Test the TickTraceService (see console output)'
         }.merge(DEBUG_LABEL_COLOR),
-        {
-          x:    600,
-          y:    200,
-          text: 'A sprite with repeating actions:'
-        }.merge(DEBUG_LABEL_COLOR)
+        @animation_label
       ]
 
       # -------------------------------------------------------------------------
@@ -313,6 +325,7 @@ module ExampleApp
       cuts = ('%04b' % (($gtk.args.tick_count / 60) % 16)).chars.map { |bit| bit == '1' }
       @glass.change_cuts(cuts)
       @glass_label.text = "Glass panel cuts: #{@glass.cuts}"
+      @animation_label.text = "A sprite (animating: #{@dragon.cur_animation}) with repeating actions:"
       mark('#update_glass_panel: complete')
     end
 

--- a/lib/zif.rb
+++ b/lib/zif.rb
@@ -1,6 +1,6 @@
 # This is the namespace for the Zif library, and in the +lib/zif.rb+ file are some miscellaneous helper methods
 module Zif
-  GTK_COMPATIBLE_VERSION = '5.4'.freeze
+  GTK_COMPATIBLE_VERSION = '5.5'.freeze
 
   # @param [Numeric] i
   # @param [Numeric] max

--- a/lib/zif/actions/actionable.rb
+++ b/lib/zif/actions/actionable.rb
@@ -107,11 +107,11 @@ module Zif
         @dirty = false
 
         @actions ||= []
-        @actions.reject! do |act|
+        @actions.each do |act|
           dirty_act = act.perform_tick
           @dirty ||= dirty_act
-          act.complete?
         end
+        @actions.reject!(&:complete?)
       end
     end
   end

--- a/lib/zif/actions/animatable.rb
+++ b/lib/zif/actions/animatable.rb
@@ -106,7 +106,8 @@ module Zif
         stop_animating
 
         @cur_animation = name
-        @animation_sequences[@cur_animation].cur_action.reset_duration
+        @animation_sequences[@cur_animation].restart
+        @animation_sequences[@cur_animation].setup_action
         # puts "Running animation sequence #{@cur_animation} #{@animation_sequences[@cur_animation].inspect}"
 
         run_action(@animation_sequences[@cur_animation])

--- a/lib/zif/actions/sequence.rb
+++ b/lib/zif/actions/sequence.rb
@@ -71,7 +71,7 @@ module Zif
       # @api private
       def setup_action
         # puts "Sequence#setup_action #{@action_index}"
-        cur_action.repeat = @sub_repeats[@action_index]
+        reset_cur_action_repeat
         cur_action.reset_start
         cur_action.reset_duration
       end
@@ -80,10 +80,17 @@ module Zif
       # @api private
       def next_action
         # puts "Sequence#next_action"
+        reset_cur_action_repeat
         @action_index = (@action_index + 1) % @sub_actions.length
         @cur_repeat -= 1 if @action_index.zero?
 
         setup_action unless complete?
+      end
+
+      # Resets the current action's {Zif::Actions::Action#repeat} to the value it was initialized with.
+      # @api private
+      def reset_cur_action_repeat
+        cur_action.repeat = @sub_repeats[@action_index]
       end
 
       # Calls the current action's {Zif::Actions::Action#perform_tick}


### PR DESCRIPTION
- Adds an example  to the `ui_sample` scene showing a one-off animation, applied to the `@dragon` when you click the button.

- Fixes the reset of the `@repeat` counts sub actions in one-off animations, allowing them to be run more than once per initialization

- Fixes animation callbacks running another animation by removing the completed action after iteration in `Actionable#perform_actions`
