### PR TITLE
Added blendmode_enum= alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ A Sequence is a series of `Zif::Actions::Action` to be run in order.  Behaves li
 **Example usage:**
 ```ruby
 @dragon.run_action(
-  Zif::Sequence.new(
+  Zif::Actions::Sequence.new(
     [
       # Move from starting position to 1000x over 1 second, starting slowly,
       # then flip the sprite at the end

--- a/lib/zif/sprite.rb
+++ b/lib/zif/sprite.rb
@@ -173,6 +173,8 @@ module Zif
       @blendmode = BLENDMODE.fetch(new_blendmode, new_blendmode)
     end
 
+    alias blendmode_enum= blend=
+
     # @return [Integer] The integer value for the specified blend mode.  See {BLENDMODE}
     # @example This always returns an integer, even if you set it using a symbol
     #   mysprite.blend = :alpha  # => 1


### PR DESCRIPTION
Added `blendmode_enum=` alias to align with DragonRuby default naming