### PR TITLE
Refactor `blendmode_enum` for v6 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ A Sequence is a series of `Zif::Actions::Action` to be run in order.  Behaves li
 **Example usage:**
 ```ruby
 @dragon.run_action(
-  Zif::Sequence.new(
+  Zif::Actions::Sequence.new(
     [
       # Move from starting position to 1000x over 1 second, starting slowly,
       # then flip the sprite at the end

--- a/lib/zif/services/action_service.rb
+++ b/lib/zif/services/action_service.rb
@@ -27,7 +27,7 @@ module Zif
       # @param [Zif::Actions::Actionable] actionable
       def register_actionable(actionable)
         unless actionable.is_a?(Zif::Actions::Actionable)
-          raise ArgumentError, 'Zif::Services::ActionService#register_actionable:' /
+          raise ArgumentError, 'Zif::Services::ActionService#register_actionable:' \
                                " #{actionable} is not a Zif::Actions::Actionable"
         end
 

--- a/lib/zif/sprite.rb
+++ b/lib/zif/sprite.rb
@@ -173,6 +173,8 @@ module Zif
       @blendmode = BLENDMODE.fetch(new_blendmode, new_blendmode)
     end
 
+    alias blendmode_enum= blend=
+
     # @return [Integer] The integer value for the specified blend mode.  See {BLENDMODE}
     # @example This always returns an integer, even if you set it using a symbol
     #   mysprite.blend = :alpha  # => 1

--- a/lib/zif/sprite.rb
+++ b/lib/zif/sprite.rb
@@ -156,7 +156,7 @@ module Zif
       @g         = 255
       @b         = 255
       @angle     = 0
-      self.blend = :alpha
+      self.blendmode_enum = :alpha
     end
 
     # @param [Hash<Symbol, Object>] sprite A hash of key-values to mass assign to a copy of this sprite.
@@ -169,21 +169,9 @@ module Zif
     # Set blend mode using either symbol names or the enum integer values.
     # @param [Symbol, Integer] new_blendmode {blend} +:none+, +:alpha+, +:add+, +:mod+, +:multiply+ or +0+, +1+, +2+, +3+, +4+. See {BLENDMODE}
     # @return [Integer] The integer value for the specified blend mode
-    def blend=(new_blendmode)
-      @blendmode = BLENDMODE.fetch(new_blendmode, new_blendmode)
+    def blendmode_enum=(new_blendmode)
+      @blendmode_enum = BLENDMODE.fetch(new_blendmode, new_blendmode)
     end
-
-    alias blendmode_enum= blend=
-
-    # @return [Integer] The integer value for the specified blend mode.  See {BLENDMODE}
-    # @example This always returns an integer, even if you set it using a symbol
-    #   mysprite.blend = :alpha  # => 1
-    #   mysprite.blend           # => 1
-    def blend
-      @blendmode
-    end
-
-    alias blendmode_enum blend
 
     # Sets {a} alpha to 255 (fully opaque)
     def show


### PR DESCRIPTION
The blendmode_enum aliases stopped working in v6, so this is a simple fix to remove the intermediary `blendmode` attribute and `blend=` method.